### PR TITLE
🔧 Fix CI workflow to trigger on 'dev' branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, master, dev]
 
 jobs:
   test-and-build:


### PR DESCRIPTION
## Summary
Quick fix to update CI workflow trigger from `develop` to `dev` to match our actual branch naming.

## Problem
- CI workflow was configured to trigger on `develop` branch
- Our actual development branch is named `dev`
- This caused CI to not run on merges to dev

## Solution
- Updated `.github/workflows/main.yml` to trigger on `dev` instead of `develop`

## Impact
✅ CI will now automatically run on all pushes and PRs to the dev branch

🤖 Generated with [Claude Code](https://claude.ai/code)