### PR TITLE
feat(ci): ✨ implement manual release control for safer publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,22 +42,64 @@ jobs:
           npm run build
 
       - name: Bump version
-        run: npm version ${{ github.event.inputs.version_type }}
+        id: version
+        run: |
+          echo "OLD_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+          echo "NEW_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        run: npx conventional-changelog-cli -p angular -i CHANGELOG.md -s -r 0
 
       - name: Package extension
         run: npm run package
 
-      - name: Publish to marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npm run deploy
+      - name: Commit version bump and changelog
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore(release): 🔖 v${{ steps.version.outputs.NEW_VERSION }}"
+          git tag v${{ steps.version.outputs.NEW_VERSION }}
+
+      - name: Push changes
+        run: |
+          git push origin HEAD:main
+          git push origin v${{ steps.version.outputs.NEW_VERSION }}
 
       - name: Create GitHub release
         uses: actions/create-release@v1
+        id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          release_name: Release v${{ steps.version.outputs.version }}
+          tag_name: v${{ steps.version.outputs.NEW_VERSION }}
+          release_name: Release v${{ steps.version.outputs.NEW_VERSION }}
+          body: |
+            ## 📦 Manual Testing Required
+
+            This release has been packaged and is ready for testing. The VSIX file is attached to this release.
+
+            ### 🧪 Testing Steps:
+            1. Download the VSIX file from this release
+            2. Install locally: `code --install-extension prompt-bank-${{ steps.version.outputs.NEW_VERSION }}.vsix`
+            3. Test the extension functionality
+            4. If everything works: publish manually with `vsce publish`
+
+            ### 📋 Changes:
+            See CHANGELOG.md for detailed changes.
+
+            ---
+            *This release was created automatically but requires manual publishing to marketplace.*
           draft: false
           prerelease: false
+
+      - name: Upload VSIX to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./prompt-bank-${{ steps.version.outputs.NEW_VERSION }}.vsix
+          asset_name: prompt-bank-${{ steps.version.outputs.NEW_VERSION }}.vsix
+          asset_content_type: application/zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,10 +154,46 @@ Uses Vitest with behavior-based testing. Tests are isolated per feature (create,
 - Maintained comprehensive CONTRIBUTING.md guide
 - Enhanced inline code documentation
 
+## Version Management & Release Process
+
+### Manual Release Control (Implemented)
+The project uses **standard-version** for semantic versioning with manual publishing control:
+
+1. **Commit Convention Impact**:
+   - `fix:` commits → Patch version (0.0.x)
+   - `feat:` commits → Minor version (0.x.0)
+   - `BREAKING CHANGE:` → Major version (x.0.0)
+
+2. **Release Workflows**:
+   - **version-bump.yml**: Manual trigger for version bumps, creates PR with changelog
+   - **release.yml**: Creates GitHub release with VSIX for manual testing/publishing
+
+3. **How to Release**:
+   ```bash
+   # Local testing
+   npm run release:dry-run  # Preview what will change
+
+   # GitHub Actions (Recommended)
+   # 1. Go to Actions tab → "Version Bump" workflow
+   # 2. Select version type (auto/patch/minor/major)
+   # 3. Review and merge the created PR
+   # 4. Use "Release" workflow to create GitHub release with VSIX
+   # 5. Download VSIX, test locally, then publish manually
+   ```
+
+4. **Manual Publishing Process**:
+   ```bash
+   # After testing the VSIX file locally:
+   vsce publish  # Publishes to VS Code Marketplace
+   # Optional: npx ovsx publish --pat <token>  # Publish to Open VSX
+   ```
+
+5. **Important**: The system uses `.versionrc.json` configuration that recognizes emoji commits. DO NOT modify version numbers manually in package.json - always use the release scripts or workflows.
+
 ## Next Steps / Potential Improvements
 
 **Immediate Priority**:
-- **Issue #24**: Implement automated version bumping workflow for releases
+- ~~**Issue #24**: Implement automated version bumping workflow for releases~~ ✅ COMPLETED
 
 **Future Enhancements**:
 1. **Template Variables**: Support for template variables in prompts (e.g., `{{selection}}`, `{{clipboard}}`)


### PR DESCRIPTION
- Remove automatic marketplace publishing from release.yml
- Keep version bumping, changelog generation, and VSIX creation
- Create GitHub release with VSIX file attached for manual testing
- Add clear testing instructions in release body
- Update CLAUDE.md with new manual release process documentation

Benefits:
- Test extension locally before publishing to marketplace
- Prevent accidental releases with bugs
- Maintain full control over when releases go live
- Still automate the tedious parts (versioning, changelog)