### PR TITLE
fix(sync): 🐛 correct 409 conflict status code detection

### DIFF
--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -593,7 +593,7 @@ export class SyncService {
         }
 
         // Check for optimistic lock conflict
-        if (error.message?.includes('conflict') || (error as { status?: number }).status === 409) {
+        if (error.message?.includes('conflict') || errorContext?.status === 409) {
           throw new Error('conflict');
         }
         throw error;


### PR DESCRIPTION
## Summary

Fixes bug where 409 conflict responses from `sync-prompt` Edge Function were not properly detected due to inconsistent error object property access.

## The Bug

When the `sync-prompt` Edge Function returned 409 (conflict), the client code was checking:
- ❌ `(error as { status?: number }).status === 409` (line 596)

But the actual error structure from Supabase client is:
- ✅ `error.context.status === 409`

This inconsistency meant 409 conflicts were:
1. Not caught by the conflict detection logic
2. Potentially misinterpreted as authentication errors
3. Showing as generic "Sync failed: sync_conflict_retry" errors

## The Fix

Changed line 596 to use the same error structure as the 401 check:
```typescript
// Before
if (error.message?.includes('conflict') || (error as { status?: number }).status === 409) {

// After  
if (error.message?.includes('conflict') || errorContext?.status === 409) {
```

Now uses `errorContext?.status` consistently with the 401 check on line 582.

## Impact

- ✅ 409 conflict responses now properly detected
- ✅ Consistent error handling pattern across all status codes
- ✅ Conflict detection now triggers as designed

## Testing

- [x] Local build successful
- [x] Tested with real 409 responses from Edge Function
- [x] Conflict detection now working (surfaces `sync_conflict_retry` as expected)

## Notes

This fix improves conflict **detection** but does not yet implement full conflict **resolution** logic. A follow-up PR will address:
- Conflict resolution handling in `executeSyncPlan`
- Retry logic in `syncCommands.ts`
- Proper handling of modify-modify conflicts

This PR keeps changes minimal and focused on the detection bug only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)