### PR TITLE
fix(sync): Resolve 409 conflict loops and corrupted state detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ dist/
 checklists
 *.vsix
 reset-vscode-view.sh
+
+# Debugging artifacts (top-level only)
+/*.png
+
+# Supabase CLI temporary files
+supabase/.temp/


### PR DESCRIPTION
## Summary

Fixes critical sync bugs causing infinite 409 conflict retry loops and handles corrupted sync state automatically.

## Changes

### Bug Fixes
- **Conflict Resolution Logic**: Changed to link `remoteCopy` to existing cloud prompt instead of deleting and re-uploading, preventing 409 conflicts
- **Corrupted State Detection**: Added automatic detection and clearing of prompts pointing to soft-deleted cloud IDs
- **Error Handling**: Comprehensive try-catch blocks with fallback logic for both localCopy and remoteCopy uploads

### Code Quality
- Removed verbose debug logging for production readiness
- Fixed TypeScript compilation errors (unused imports/variables)
- Applied Prettier formatting

### Housekeeping
- Added `.gitignore` patterns for debugging artifacts (`/*.png`) and Supabase CLI temp files (`supabase/.temp/`)

## Root Cause

The previous conflict resolution logic would:
1. Delete the cloud prompt
2. Try to upload both localCopy and remoteCopy as NEW
3. Edge function detected soft-deleted prompt still exists → 409 conflict
4. Retry logic triggered → infinite loop

## Solution

New approach:
1. Upload localCopy as NEW cloud prompt ✅
2. Link remoteCopy to EXISTING cloud prompt (no upload) ✅
3. Fallback: If linking fails, upload remoteCopy as NEW ✅

## Testing

- ✅ All existing tests passing (78 passed | 9 skipped)
- ✅ TypeScript compilation successful
- ✅ Prettier formatting applied
- ✅ Build successful (585.5kb)
- ⚠️ **TODO**: Add comprehensive sync feature tests (separate effort)

## Related Issues

Resolves the "joke prompt" corruption issue where sync state pointed to deleted cloud prompt.

## Next Steps

After merge:
1. Implement comprehensive sync tests (new branch)
2. Test scenarios: first sync, conflicts, corrupted state, quota checks, simultaneous syncs
3. Version bump and release after tests complete