### PR TITLE
fix: add root-level storage files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ reset-vscode-view.sh
 # Supabase CLI temporary files
 supabase/.temp/
 *.vsix
+
+# Test/development prompt storage files (prevent accidental commits)
+/prompts.json
+/metadata.json
+/sync-state.json


### PR DESCRIPTION
## Summary

Fixes the annoying \"untracked files\" issue when developing the extension by adding explicit gitignore entries for test/development storage files.

## Problem

When testing the extension locally, `prompts.json` and `metadata.json` files were being created in the project root directory (instead of `.vscode/prompt-bank/` where they belong). These files show up as untracked in `git status`, causing confusion.

## Root Cause

The extension's storage logic falls back to the current directory when no workspace is open, creating these files in the project root during development/testing.

## Solution

Added explicit gitignore entries for root-level storage files:
- `/prompts.json`
- `/metadata.json`
- `/sync-state.json`

Also removed existing test files from the repository.

## Note

The actual production storage uses `.vscode/prompt-bank/` which is already properly gitignored. This fix only addresses development/testing scenarios.

## Testing

- ✅ Files deleted from root
- ✅ `.gitignore` updated with root-level entries
- ✅ `git status` now clean

## Checklist

- [x] Conventional commit format used (`fix(gitignore): 🙈 ...`)
- [x] Test files removed
- [x] Comments explain the entries
- [x] No functional code changes