### PR TITLE
feat(ux): ✨ add "+" button to tree view for quick prompt creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,12 @@
         "category": "Prompt Bank"
       },
       {
+        "command": "promptBank.newPrompt",
+        "title": "New Prompt",
+        "icon": "$(add)",
+        "category": "Prompt Bank"
+      },
+      {
         "command": "promptBank.refreshTreeView",
         "title": "Refresh Prompts",
         "icon": "$(refresh)",
@@ -171,6 +177,11 @@
         }
       ],
       "view/title": [
+        {
+          "command": "promptBank.newPrompt",
+          "when": "view == promptBank.promptsView",
+          "group": "navigation@1"
+        },
         {
           "command": "promptBank.refreshTreeView",
           "when": "view == promptBank.promptsView",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -273,6 +273,15 @@ export function registerCommands(
     }
   );
 
+  // Register new prompt command (tree view "+" button)
+  const newPromptCommand = vscode.commands.registerCommand('promptBank.newPrompt', async () => {
+    try {
+      await PromptEditorPanel.showForNewPrompt(context, '', promptService, treeProvider);
+    } catch (error) {
+      vscode.window.showErrorMessage(`Error creating new prompt: ${error}`);
+    }
+  });
+
   // Add all commands to context subscriptions
   context.subscriptions.push(
     savePromptCommand,
@@ -281,6 +290,7 @@ export function registerCommands(
     listPromptsCommand,
     showStatsCommand,
     importPromptCommand,
-    shareCollectionCommand
+    shareCollectionCommand,
+    newPromptCommand
   );
 }

--- a/src/views/promptTreeItem.ts
+++ b/src/views/promptTreeItem.ts
@@ -75,12 +75,12 @@ export class PromptTreeItem extends BaseTreeItem {
 export class EmptyStateTreeItem extends BaseTreeItem {
   constructor() {
     super(
-      'No prompts found. Use the Command Palette (Ctrl+Shift+P) to add your first prompt!',
+      'No prompts yet. Click the + button above to create your first!',
       vscode.TreeItemCollapsibleState.None
     );
     this.contextValue = 'empty';
     this.iconPath = new vscode.ThemeIcon('info');
-    this.tooltip = 'Prompt Bank is empty. Start by adding a prompt from the Command Palette!';
+    this.tooltip = 'Prompt Bank is empty. Click the + button in the title bar to add a prompt!';
   }
 }
 

--- a/test/new-prompt-command.test.ts
+++ b/test/new-prompt-command.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PromptEditorPanel } from '../src/webview/PromptEditorPanel';
+import { PromptService } from '../src/services/promptService';
+import { PromptTreeProvider } from '../src/views/promptTreeProvider';
+import { FileStorageProvider } from '../src/storage/fileStorage';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock file system for reading HTML files
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(() => '<html>Mock HTML Content</html>'),
+  };
+});
+
+describe('New Prompt Command (promptBank.newPrompt)', () => {
+  let promptService: PromptService;
+  let treeProvider: PromptTreeProvider;
+  let storageProvider: FileStorageProvider;
+  let testStorageDir: string;
+  let vscode: any;
+  let mockWebviewPanel: any;
+  let mockContext: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    vscode = await import('vscode');
+
+    // Create mock webview panel
+    mockWebviewPanel = {
+      webview: {
+        html: '',
+        onDidReceiveMessage: vi.fn(),
+        postMessage: vi.fn(),
+      },
+      dispose: vi.fn(),
+      onDidDispose: vi.fn(),
+    };
+
+    vscode.window.createWebviewPanel.mockReturnValue(mockWebviewPanel);
+
+    mockContext = {
+      extensionUri: { fsPath: '/mock/extension/path' },
+      subscriptions: [],
+    };
+
+    // Create test storage
+    testStorageDir = path.join(
+      os.tmpdir(),
+      `prompt-bank-test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    );
+    storageProvider = new FileStorageProvider({ storagePath: testStorageDir });
+    await storageProvider.initialize();
+
+    promptService = new PromptService(storageProvider);
+    await promptService.initialize();
+
+    treeProvider = {
+      refresh: vi.fn(),
+    } as any;
+  });
+
+  afterEach(async () => {
+    await fs.rm(testStorageDir, { recursive: true, force: true }).catch(() => {});
+    vi.clearAllMocks();
+  });
+
+  describe('Opening Editor Panel', () => {
+    it('should open prompt editor panel with empty content', async () => {
+      const panel = await PromptEditorPanel.showForNewPrompt(
+        mockContext as any,
+        '', // Empty content - this is what newPrompt command does
+        promptService,
+        treeProvider
+      );
+
+      expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+        'promptEditor',
+        'New Prompt',
+        1, // ViewColumn.One
+        expect.any(Object)
+      );
+    });
+
+    it('should set up message handler for webview communication', async () => {
+      await PromptEditorPanel.showForNewPrompt(mockContext as any, '', promptService, treeProvider);
+
+      expect(mockWebviewPanel.webview.onDidReceiveMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('Saving New Prompt', () => {
+    it('should save prompt when user fills form and submits', async () => {
+      const saveSpy = vi.spyOn(promptService, 'savePromptDirectly');
+
+      await PromptEditorPanel.showForNewPrompt(mockContext as any, '', promptService, treeProvider);
+
+      // Simulate user filling the form and saving
+      const messageHandler = mockWebviewPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      await messageHandler({
+        type: 'save',
+        data: {
+          title: 'My New Prompt',
+          content: 'User typed this content',
+          category: 'General',
+          description: 'A helpful prompt',
+        },
+      });
+
+      expect(saveSpy).toHaveBeenCalled();
+      const savedPrompt = saveSpy.mock.calls[0][0];
+      expect(savedPrompt.title).toBe('My New Prompt');
+      expect(savedPrompt.content).toBe('User typed this content');
+      expect(savedPrompt.category).toBe('General');
+      expect(savedPrompt.description).toBe('A helpful prompt');
+    });
+
+    it('should refresh tree view after saving new prompt', async () => {
+      await PromptEditorPanel.showForNewPrompt(mockContext as any, '', promptService, treeProvider);
+
+      const messageHandler = mockWebviewPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      await messageHandler({
+        type: 'save',
+        data: {
+          title: 'Test Prompt',
+          content: 'Test content',
+          category: 'Testing',
+          description: '',
+        },
+      });
+
+      expect(treeProvider.refresh).toHaveBeenCalled();
+    });
+
+    it('should handle saving prompt without description', async () => {
+      const saveSpy = vi.spyOn(promptService, 'savePromptDirectly');
+
+      await PromptEditorPanel.showForNewPrompt(mockContext as any, '', promptService, treeProvider);
+
+      const messageHandler = mockWebviewPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      await messageHandler({
+        type: 'save',
+        data: {
+          title: 'No Description',
+          content: 'Some content',
+          category: 'General',
+          description: '', // Empty description
+        },
+      });
+
+      expect(saveSpy).toHaveBeenCalled();
+      const savedPrompt = saveSpy.mock.calls[0][0];
+      expect(savedPrompt.description).toBeUndefined();
+    });
+
+    it('should handle saving prompt with new category', async () => {
+      const saveSpy = vi.spyOn(promptService, 'savePromptDirectly');
+
+      await PromptEditorPanel.showForNewPrompt(mockContext as any, '', promptService, treeProvider);
+
+      const messageHandler = mockWebviewPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      await messageHandler({
+        type: 'save',
+        data: {
+          title: 'First in Category',
+          content: 'Content here',
+          category: 'Brand New Category',
+          description: '',
+        },
+      });
+
+      expect(saveSpy).toHaveBeenCalled();
+      const savedPrompt = saveSpy.mock.calls[0][0];
+      expect(savedPrompt.category).toBe('Brand New Category');
+    });
+  });
+
+  describe('Cancel Operation', () => {
+    it('should dispose panel when cancel message received', async () => {
+      await PromptEditorPanel.showForNewPrompt(mockContext as any, '', promptService, treeProvider);
+
+      const messageHandler = mockWebviewPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      await messageHandler({ type: 'cancel' });
+
+      expect(mockWebviewPanel.dispose).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a "+" button to the Prompt Bank tree view title bar for one-click prompt creation
- Reduces friction for new users by providing a visible entry point
- Updates empty state message to guide users to the new button

## Changes
- Add `promptBank.newPrompt` command with `$(add)` icon
- Place button in tree title bar next to refresh button (`navigation@1`)
- Open blank prompt editor when clicked
- Update empty state message: "No prompts yet. Click the + button above to create your first!"
- Add 7 unit tests for the new command

## Test plan
- [x] Build passes
- [x] All 179 tests pass (including 7 new tests)
- [x] TypeScript type check passes
- [x] VSIX tested locally - button appears and works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)