### PR TITLE
feat(ux): ✨ make empty state clickable to create new prompt

### DIFF
--- a/src/views/promptTreeItem.ts
+++ b/src/views/promptTreeItem.ts
@@ -71,16 +71,18 @@ export class PromptTreeItem extends BaseTreeItem {
 
 /**
  * Tree item representing an empty state (no prompts/categories)
+ * Clickable - opens the prompt editor when selected
  */
 export class EmptyStateTreeItem extends BaseTreeItem {
   constructor() {
-    super(
-      'No prompts yet. Click the + button above to create your first!',
-      vscode.TreeItemCollapsibleState.None
-    );
+    super('Click here to create your first prompt!', vscode.TreeItemCollapsibleState.None);
     this.contextValue = 'empty';
-    this.iconPath = new vscode.ThemeIcon('info');
-    this.tooltip = 'Prompt Bank is empty. Click the + button in the title bar to add a prompt!';
+    this.iconPath = new vscode.ThemeIcon('add');
+    this.tooltip = 'Click to create a new prompt';
+    this.command = {
+      command: 'promptBank.newPrompt',
+      title: 'Create New Prompt',
+    };
   }
 }
 

--- a/test/empty-state-tree-item.test.ts
+++ b/test/empty-state-tree-item.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EmptyStateTreeItem } from '../src/views/promptTreeItem';
+import * as vscode from 'vscode';
+
+describe('EmptyStateTreeItem', () => {
+  let emptyStateItem: EmptyStateTreeItem;
+
+  beforeEach(() => {
+    emptyStateItem = new EmptyStateTreeItem();
+  });
+
+  describe('Display Properties', () => {
+    it('should have action-oriented label text', () => {
+      expect(emptyStateItem.label).toBe('Click here to create your first prompt!');
+    });
+
+    it('should have helpful tooltip', () => {
+      expect(emptyStateItem.tooltip).toBe('Click to create a new prompt');
+    });
+
+    it('should use add icon to indicate action', () => {
+      const icon = emptyStateItem.iconPath as vscode.ThemeIcon;
+      expect(icon.id).toBe('add');
+    });
+
+    it('should not be collapsible', () => {
+      expect(emptyStateItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+    });
+
+    it('should have empty context value', () => {
+      expect(emptyStateItem.contextValue).toBe('empty');
+    });
+  });
+
+  describe('Click Behavior', () => {
+    it('should have command property set', () => {
+      expect(emptyStateItem.command).toBeDefined();
+    });
+
+    it('should execute promptBank.newPrompt command when clicked', () => {
+      expect(emptyStateItem.command?.command).toBe('promptBank.newPrompt');
+    });
+
+    it('should have descriptive command title', () => {
+      expect(emptyStateItem.command?.title).toBe('Create New Prompt');
+    });
+  });
+});

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -15,7 +15,32 @@ function generateWorkspacePath(): string {
 
 // Mock 'vscode' at the top level to ensure it's mocked before any imports
 vi.mock('vscode', () => {
+  // Mock TreeItem class
+  class MockTreeItem {
+    label: string;
+    collapsibleState: number;
+    tooltip?: string;
+    description?: string;
+    contextValue?: string;
+    iconPath?: any;
+    command?: any;
+
+    constructor(label: string, collapsibleState?: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState ?? 0;
+    }
+  }
+
   return {
+    TreeItem: MockTreeItem,
+    TreeItemCollapsibleState: {
+      None: 0,
+      Collapsed: 1,
+      Expanded: 2,
+    },
+    ThemeIcon: class {
+      constructor(public id: string) {}
+    },
     window: {
       showInputBox: vi.fn(),
       showQuickPick: vi.fn(),


### PR DESCRIPTION
## Summary
- Make empty state tree item clickable to directly open prompt editor
- Phase 2 of the UX improvement plan (following PR #59)
- Reduces friction further for new users by making the empty state actionable

## Changes
- Add `command` property to `EmptyStateTreeItem` that triggers `promptBank.newPrompt`
- Change icon from `info` to `add` for clearer action affordance  
- Update label to action-oriented: "Click here to create your first prompt!"
- Add 8 unit tests for empty state tree item behavior
- Extend VS Code test mock with TreeItem, TreeItemCollapsibleState, ThemeIcon

## Test plan
- [x] Build passes
- [x] All 187 tests pass (including 8 new tests)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)