### PR TITLE
fix(storage): 🐛 use correct .vscode/prompt-bank path in ServicesContainer

### DIFF
--- a/src/services/servicesContainer.ts
+++ b/src/services/servicesContainer.ts
@@ -163,8 +163,9 @@ export class ServicesContainer {
     // 3. Workspace metadata service (for workspace identity)
     const workspaceMetadataService = new WorkspaceMetadataService(workspaceRoot, context);
 
-    // 4. Storage providers
-    const storageProvider = new FileStorageProvider({ storagePath: workspaceRoot });
+    // 4. Storage providers (store in .vscode/prompt-bank subdirectory)
+    const storagePath = path.join(workspaceRoot, '.vscode', 'prompt-bank');
+    const storageProvider = new FileStorageProvider({ storagePath });
     await storageProvider.initialize();
 
     const syncStateStorage = new SyncStateStorage(workspaceRoot);


### PR DESCRIPTION
## Summary

- Fix storage path bug where files were created in workspace root instead of `.vscode/prompt-bank/`

## Problem

When `ServicesContainer` created `FileStorageProvider`, it passed `workspaceRoot` directly as the storage path:

```typescript
const storageProvider = new FileStorageProvider({ storagePath: workspaceRoot });
```

This bypassed `FileStorageProvider`'s default logic that appends `.vscode/prompt-bank` to the path, causing `prompts.json` and `metadata.json` to be created in the project root folder.

## Solution

Explicitly construct the correct path before passing it to the provider:

```typescript
const storagePath = path.join(workspaceRoot, '.vscode', 'prompt-bank');
const storageProvider = new FileStorageProvider({ storagePath });
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 192 tests pass (`npm run test`)
- [x] Manual verification: Initialize Prompt Bank in a new folder and confirm files are only created in `.vscode/prompt-bank/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)