### PR TITLE
refactor: migrate to unified Supabase backend with centralized config

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
         "promptBank.supabaseAnonKey": {
           "type": "string",
           "default": "sb_publishable_4YWhPqX2HleOm9-vCKVSEA_daIYTGwZ",
-          "description": "Supabase publishable API key (safe to expose - security enforced via RLS policies)"
+          "description": "Supabase publishable API key"
         },
         "promptBank.publicShareBase": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -249,8 +249,13 @@
       "properties": {
         "promptBank.supabaseUrl": {
           "type": "string",
-          "default": "https://xlqtowactrzmslpkzliq.supabase.co",
+          "default": "https://ejolajleumgrgnmygxmz.supabase.co",
           "description": "Supabase project base URL used for authentication and sharing"
+        },
+        "promptBank.supabaseAnonKey": {
+          "type": "string",
+          "default": "sb_publishable_4YWhPqX2HleOm9-vCKVSEA_daIYTGwZ",
+          "description": "Supabase publishable API key (safe to expose - security enforced via RLS policies)"
         },
         "promptBank.publicShareBase": {
           "type": "string",

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -1,0 +1,55 @@
+/**
+ * Supabase Configuration
+ *
+ * Single source of truth for Supabase connection settings.
+ * All services should import from this module rather than
+ * defining their own defaults.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Default Supabase configuration values
+ *
+ * These point to the unified prompt-bank-website project
+ * which serves both the website and VS Code extension.
+ */
+export const SUPABASE_DEFAULTS = {
+  /** Supabase project URL */
+  url: 'https://ejolajleumgrgnmygxmz.supabase.co',
+
+  /**
+   * Publishable API key (replaces legacy anon key)
+   *
+   * Safe to expose in client-side code - security is enforced
+   * via Row Level Security (RLS) policies, not key secrecy.
+   *
+   * @see https://supabase.com/docs/guides/api/api-keys
+   */
+  publishableKey: 'sb_publishable_4YWhPqX2HleOm9-vCKVSEA_daIYTGwZ',
+
+  /** Base URL for public share links */
+  publicShareBase: 'https://prestissimo.ai/share/',
+} as const;
+
+/**
+ * Get Supabase configuration from VS Code settings with defaults
+ *
+ * Users can override these values via VS Code settings:
+ * - promptBank.supabaseUrl
+ * - promptBank.supabaseAnonKey (kept for backward compatibility)
+ * - promptBank.publicShareBase
+ *
+ * @returns Supabase configuration object
+ */
+export function getSupabaseConfig() {
+  const cfg = vscode.workspace.getConfiguration('promptBank');
+
+  return {
+    url: cfg.get<string>('supabaseUrl', SUPABASE_DEFAULTS.url),
+    // Setting name kept as 'supabaseAnonKey' for backward compatibility
+    // with existing user configurations, but now uses publishable key
+    publishableKey: cfg.get<string>('supabaseAnonKey', SUPABASE_DEFAULTS.publishableKey),
+    publicShareBase: cfg.get<string>('publicShareBase', SUPABASE_DEFAULTS.publicShareBase),
+  };
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { jwtVerify, createRemoteJWKSet, type JWTPayload } from 'jose';
+import { getSupabaseConfig } from '../config/supabase';
 
 // Supabase API response types
 interface TokenResponse {
@@ -68,12 +69,9 @@ export class AuthService {
     publisher: string,
     extensionName: string
   ) {
-    const cfg = vscode.workspace.getConfiguration('promptBank');
-    this.supabaseUrl = cfg.get<string>('supabaseUrl', 'https://xlqtowactrzmslpkzliq.supabase.co');
-    this.supabaseAnonKey = cfg.get<string>(
-      'supabaseAnonKey',
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhscXRvd2FjdHJ6bXNscGt6bGlxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIyMDAzMzQsImV4cCI6MjA2Nzc3NjMzNH0.cUVLqlGGWfaxDs49AQ57rHxruj52MphG9jV1e0F1UYo'
-    );
+    const config = getSupabaseConfig();
+    this.supabaseUrl = config.url;
+    this.supabaseAnonKey = config.publishableKey;
     this.publisher = publisher;
     this.extensionName = extensionName;
   }

--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -6,7 +6,7 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import * as vscode from 'vscode';
+import { getSupabaseConfig } from '../config/supabase';
 
 /**
  * Database schema types for type-safe queries
@@ -56,17 +56,9 @@ class SupabaseClientManager {
    */
   public static initialize(): SupabaseClient<Database> {
     if (!SupabaseClientManager.instance) {
-      const cfg = vscode.workspace.getConfiguration('promptBank');
-      const supabaseUrl = cfg.get<string>(
-        'supabaseUrl',
-        'https://xlqtowactrzmslpkzliq.supabase.co'
-      );
-      const supabaseAnonKey = cfg.get<string>(
-        'supabaseAnonKey',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhscXRvd2FjdHJ6bXNscGt6bGlxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIyMDAzMzQsImV4cCI6MjA2Nzc3NjMzNH0.cUVLqlGGWfaxDs49AQ57rHxruj52MphG9jV1e0F1UYo'
-      );
+      const config = getSupabaseConfig();
 
-      SupabaseClientManager.instance = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+      SupabaseClientManager.instance = createClient<Database>(config.url, config.publishableKey, {
         auth: {
           // Disable auto-refresh since we handle tokens manually in AuthService
           autoRefreshToken: false,

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -101,17 +101,18 @@ vi.mock('vscode', () => {
       },
       getConfiguration: vi.fn((section?: string) => {
         // Handle promptBank configuration for Supabase
+        // These values must match SUPABASE_DEFAULTS in src/config/supabase.ts
         if (section === 'promptBank') {
           return {
             get: vi.fn((key: string, defaultValue?: any) => {
               if (key === 'supabaseUrl') {
-                return defaultValue || 'https://xlqtowactrzmslpkzliq.supabase.co';
+                return defaultValue || 'https://ejolajleumgrgnmygxmz.supabase.co';
               }
               if (key === 'supabaseAnonKey') {
-                return (
-                  defaultValue ||
-                  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhscXRvd2FjdHJ6bXNscGt6bGlxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIyMDAzMzQsImV4cCI6MjA2Nzc3NjMzNH0.cUVLqlGGWfaxDs49AQ57rHxruj52MphG9jV1e0F1UYo'
-                );
+                return defaultValue || 'sb_publishable_4YWhPqX2HleOm9-vCKVSEA_daIYTGwZ';
+              }
+              if (key === 'publicShareBase') {
+                return defaultValue || 'https://prestissimo.ai/share/';
               }
               return defaultValue;
             }),


### PR DESCRIPTION
## Summary

- **Centralize Supabase configuration** into single source of truth (`src/config/supabase.ts`)
- **Migrate to unified backend** (`ejolajleumgrgnmygxmz`) that serves both website and VS Code extension
- **Adopt publishable key format** (`sb_publishable_...`) per Supabase 2025/2026 best practices

## Changes

### New File
- `src/config/supabase.ts` - Single source of truth for Supabase URL, publishable key, and share base URL

### Updated Files
- `src/services/supabaseClient.ts` - Import from centralized config
- `src/services/authService.ts` - Import from centralized config
- `src/services/shareService.ts` - Import from centralized config (also fixed inconsistent legacy key)
- `test/test-setup.ts` - Updated mocks to use new project values
- `package.json` - Updated default URL and added `supabaseAnonKey` setting

## Why This Change

1. **DRY principle** - Previously URL/key were hardcoded in 3 files with duplicate (and inconsistent!) values
2. **Modern auth** - Publishable keys are the recommended format, support independent rotation
3. **Unified backend** - Enables prompt sync between VS Code extension and website

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] All 174 tests pass (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)