### PR TITLE
fix(sync): resolve hash mismatch and use latest-wins conflict strategy

### DIFF
--- a/src/commands/treeCommands.ts
+++ b/src/commands/treeCommands.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Prompt } from '../models/prompt';
+import { Prompt, DEFAULT_CATEGORY } from '../models/prompt';
 import { PromptTreeProvider } from '../views/promptTreeProvider';
 import { PromptService } from '../services/promptService';
 import { PromptTreeItem, CategoryTreeItem } from '../views/promptTreeItem';
@@ -36,7 +36,7 @@ export class TreeCommands {
           vscode.window.showErrorMessage('Extension context not available');
           return;
         }
-        const category = item?.category || 'General';
+        const category = item?.category || DEFAULT_CATEGORY;
         await PromptEditorPanel.showForNewPrompt(
           this.context,
           '',

--- a/src/models/prompt.ts
+++ b/src/models/prompt.ts
@@ -1,5 +1,19 @@
 import { randomUUID } from 'crypto';
 
+// ────────────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Default category for prompts when none is specified */
+export const DEFAULT_CATEGORY = 'General';
+
+/** Predefined categories shown in the UI */
+export const PREDEFINED_CATEGORIES = [DEFAULT_CATEGORY, 'Architecture', 'UI/UX', 'Testing'];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Interfaces
+// ────────────────────────────────────────────────────────────────────────────
+
 /**
  * Core prompt model with extensible structure for future features
  */
@@ -89,8 +103,8 @@ export interface FileContext {
 export function createPrompt(
   title: string,
   content: string,
-  category: string = 'General',
-  description?: string // Add description as an optional parameter
+  category: string = DEFAULT_CATEGORY,
+  description?: string
 ): Prompt {
   const newPrompt: Prompt = {
     id: generateId(),

--- a/src/services/promptService.ts
+++ b/src/services/promptService.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { Prompt, createPrompt } from '../models/prompt';
+import { Prompt, createPrompt, PREDEFINED_CATEGORIES } from '../models/prompt';
 import { IStorageProvider, PromptFilter } from '../storage/interfaces';
 import { FileStorageProvider } from '../storage/fileStorage';
 import { createShareMulti } from './shareService';
@@ -582,7 +582,7 @@ export class PromptService {
     const prompts = await this.storage.list();
     const existingCategories = [...new Set(prompts.map((p) => p.category))];
 
-    const predefinedCategories = ['General', 'Architecture', 'UI/UX', 'Testing'];
+    const predefinedCategories = PREDEFINED_CATEGORIES;
 
     // Combine and deduplicate categories
     const allCategories = [...new Set([...predefinedCategories, ...existingCategories])];

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -12,6 +12,7 @@
  */
 
 import * as vscode from 'vscode';
+import { DEFAULT_CATEGORY } from '../models/prompt';
 import type { Prompt, TemplateVariable, FileContext } from '../models/prompt';
 import type {
   SyncState,
@@ -31,9 +32,6 @@ import { SupabaseClientManager } from './supabaseClient';
 import { computeContentHash, matchesHash } from '../utils/contentHash';
 import { getDeviceInfo } from '../utils/deviceId';
 import type { PromptService } from './promptService';
-
-/** Default category for prompts when none is specified or value is null */
-const DEFAULT_CATEGORY = 'General';
 
 /**
  * Sync service using dependency injection

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -241,64 +241,29 @@ export class SyncService {
   // ────────────────────────────────────────────────────────────────────────────
 
   /**
-   * Resolve conflict by creating two separate prompts with device names
+   * Resolve conflict using "latest wins" strategy
    *
-   * CRITICAL: Strips existing conflict suffixes to prevent nesting
-   * CRITICAL: Both prompts get NEW IDs (no reuse)
+   * Compares timestamps and returns only the newer version.
+   * This prevents duplicate prompts from accumulating.
    *
    * @param local - Local version of prompt
    * @param remote - Remote version of prompt
-   * @returns Array of [localCopy, remoteCopy] with new IDs and suffixed names
+   * @returns Object with winner ('local' | 'remote') and the winning prompt
    */
-  private async resolveConflict(
+  private resolveConflict(
     local: Prompt,
     remote: RemotePrompt
-  ): Promise<readonly [Prompt, Prompt]> {
-    // Strip existing conflict suffixes to prevent nesting
-    // Pattern matches: " (from Device Name - Oct 27)" or " (from Device - Jan 1)"
-    const suffixPattern = / \(from .+ - \w{3} \d{1,2}\)$/;
-    const baseTitle = local.title.replace(suffixPattern, '');
+  ): { winner: 'local' | 'remote'; prompt: Prompt } {
+    const localModified = local.metadata.modified.getTime();
+    const remoteModified = new Date(remote.updated_at).getTime();
 
-    const syncState = await this.syncStateStorage!.getSyncState();
-    const localDeviceName = syncState?.deviceName || 'Unknown Device';
-
-    // Parse remote device name from sync_metadata
-    const remoteSyncMeta = remote.sync_metadata as { lastModifiedDeviceName?: string } | null;
-    const remoteDeviceName = remoteSyncMeta?.lastModifiedDeviceName || 'Unknown Device';
-
-    // Format date with time to ensure uniqueness
-    const formatDateTime = (date: Date): string => {
-      const months = [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec',
-      ];
-      const hours = date.getHours().toString().padStart(2, '0');
-      const minutes = date.getMinutes().toString().padStart(2, '0');
-      return `${months[date.getMonth()]} ${date.getDate()} ${hours}:${minutes}`;
-    };
-
-    // Create two separate prompts with NEW IDs for both
-    const localCopy: Prompt = {
-      ...local,
-      id: this.generateNewId(), // NEW ID (don't reuse original)
-      title: `${baseTitle} (from ${localDeviceName} - ${formatDateTime(local.metadata.modified)})`,
-    };
-
-    const remoteCopy: Prompt = this.convertRemoteToLocal(remote);
-    remoteCopy.id = this.generateNewId(); // NEW ID (don't reuse remote's ID)
-    remoteCopy.title = `${baseTitle} (from ${remoteDeviceName} - ${formatDateTime(new Date(remote.updated_at))})`;
-
-    return [localCopy, remoteCopy] as const;
+    if (localModified >= remoteModified) {
+      // Local is newer or same time - keep local
+      return { winner: 'local', prompt: local };
+    } else {
+      // Remote is newer - convert and keep remote
+      return { winner: 'remote', prompt: this.convertRemoteToLocal(remote) };
+    }
   }
 
   /**
@@ -320,7 +285,7 @@ export class SyncService {
       id: remote.local_id,
       title: remote.title,
       content: remote.content,
-      category: remote.category,
+      category: remote.category || 'General', // Ensure never null
       variables: variables,
       metadata: {
         created: new Date(metadata.created),
@@ -833,70 +798,40 @@ export class SyncService {
     const startTime = Date.now();
 
     try {
-      // 1. Handle conflicts first (create local duplicates)
+      // 1. Handle conflicts using "latest wins" strategy
       for (const conflict of plan.conflicts) {
         const localPrompt = conflict.local as Prompt;
-        const [localCopy, remoteCopy] = await this.resolveConflict(localPrompt, conflict.remote);
+        const { winner, prompt: winningPrompt } = this.resolveConflict(localPrompt, conflict.remote);
 
-        // Save both conflict copies locally with device-specific names
-        await promptService.savePromptDirectly(localCopy);
-        await promptService.savePromptDirectly(remoteCopy);
+        if (winner === 'local') {
+          // Local is newer - upload to overwrite remote
+          const syncInfo = await this.syncStateStorage!.getPromptSyncInfo(localPrompt.id);
+          const uploaded = await this.uploadWithConflictHandling(localPrompt, syncInfo ?? undefined);
+          const contentHash = computeContentHash(localPrompt);
 
-        // Delete the original LOCAL prompt from prompts.json
-        // (it's being replaced by two new copies with device-specific names)
-        await promptService.deletePromptById(localPrompt.id);
-
-        // Mark the original local prompt as deleted in sync state
-        await this.syncStateStorage!.markPromptAsDeleted(localPrompt.id);
-
-        // Compute content hashes for both copies
-        const localHash = computeContentHash(localCopy);
-        const remoteHash = computeContentHash(remoteCopy);
-
-        try {
-          // Upload localCopy as a NEW cloud prompt (representing the local version)
-          const localCloudId = await this.uploadPrompt(localCopy);
-
-          // Create sync info for localCopy pointing to its NEW cloud ID
-          await this.syncStateStorage!.setPromptSyncInfo(localCopy.id, {
-            cloudId: localCloudId.cloudId,
-            lastSyncedContentHash: localHash,
+          await this.syncStateStorage!.setPromptSyncInfo(localPrompt.id, {
+            cloudId: uploaded.cloudId,
+            lastSyncedContentHash: contentHash,
             lastSyncedAt: new Date(),
-            version: localCloudId.version,
+            version: uploaded.version,
           });
-        } catch (error) {
-          // If localCopy upload fails, we should still continue with remoteCopy
-          // The localCopy exists locally, and we can retry upload on next sync
-        }
+        } else {
+          // Remote is newer - download to overwrite local
+          // Update the existing local prompt with remote content
+          const updatedPrompt: Prompt = {
+            ...winningPrompt,
+            id: localPrompt.id, // Keep the original local ID
+          };
 
-        try {
-          // Link remoteCopy to the EXISTING cloud prompt (representing the remote version)
-          // DON'T upload remoteCopy - it already exists in the cloud as conflict.remote
-          // This avoids 409 conflicts and preserves the remote prompt in the cloud
+          await promptService.savePromptDirectly(updatedPrompt);
 
-          // Create sync info for remoteCopy pointing to the EXISTING cloud ID
-          await this.syncStateStorage!.setPromptSyncInfo(remoteCopy.id, {
+          const contentHash = computeContentHash(updatedPrompt);
+          await this.syncStateStorage!.setPromptSyncInfo(localPrompt.id, {
             cloudId: conflict.remote.cloud_id,
-            lastSyncedContentHash: remoteHash,
+            lastSyncedContentHash: contentHash,
             lastSyncedAt: new Date(),
             version: conflict.remote.version,
           });
-        } catch (error) {
-          // Edge case: If the remote cloud prompt was deleted by another device
-          // between fetch and conflict resolution, we should upload remoteCopy as NEW
-          try {
-            const remoteCloudId = await this.uploadPrompt(remoteCopy);
-
-            await this.syncStateStorage!.setPromptSyncInfo(remoteCopy.id, {
-              cloudId: remoteCloudId.cloudId,
-              lastSyncedContentHash: remoteHash,
-              lastSyncedAt: new Date(),
-              version: remoteCloudId.version,
-            });
-          } catch (uploadError) {
-            // If both linking and uploading fail, remoteCopy exists locally
-            // We can retry on next sync
-          }
         }
 
         result.stats.conflicts++;

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -32,6 +32,9 @@ import { computeContentHash, matchesHash } from '../utils/contentHash';
 import { getDeviceInfo } from '../utils/deviceId';
 import type { PromptService } from './promptService';
 
+/** Default category for prompts when none is specified or value is null */
+const DEFAULT_CATEGORY = 'General';
+
 /**
  * Sync service using dependency injection
  *
@@ -344,7 +347,7 @@ export class SyncService {
       id: remote.local_id,
       title: remote.title,
       content: remote.content,
-      category: remote.category || 'General', // Ensure never null
+      category: remote.category || DEFAULT_CATEGORY,
       variables: variables,
       metadata: {
         created: new Date(metadata.created),

--- a/src/utils/contentHash.ts
+++ b/src/utils/contentHash.ts
@@ -32,10 +32,11 @@ import type { Prompt } from '../models/prompt';
  */
 export const computeContentHash = (prompt: Prompt): string => {
   // Canonical representation - order matters for consistent hashing
+  // CRITICAL: Must match web's implementation in promptbank-website/src/lib/utils/content-hash.ts
   const canonical = JSON.stringify({
     title: prompt.title.trim(),
     content: prompt.content.trim(),
-    category: prompt.category.trim(),
+    category: (prompt.category || '').trim(), // Handle null/undefined to match web
     // Note: We intentionally exclude:
     // - metadata (created, modified, usageCount) - these change frequently
     // - variables - these are derived from content

--- a/src/webview/PromptEditorPanel.ts
+++ b/src/webview/PromptEditorPanel.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { PromptService } from '../services/promptService';
 import { PromptTreeProvider } from '../views/promptTreeProvider';
-import { Prompt, createPrompt } from '../models/prompt';
+import { Prompt, createPrompt, DEFAULT_CATEGORY } from '../models/prompt';
 import { WebViewCache } from './WebViewCache';
 
 export class PromptEditorPanel {
@@ -92,7 +92,7 @@ export class PromptEditorPanel {
       categories = Array.from(new Set(prompts.map((p) => p.category))).sort();
       // Ensure we always have at least one category
       if (categories.length === 0) {
-        categories = ['General'];
+        categories = [DEFAULT_CATEGORY];
       }
       WebViewCache.setCategoriesCache(categories);
     }
@@ -132,7 +132,7 @@ export class PromptEditorPanel {
       categories = Array.from(new Set(prompts.map((p) => p.category))).sort();
       // Ensure we always have at least one category
       if (categories.length === 0) {
-        categories = ['General'];
+        categories = [DEFAULT_CATEGORY];
       }
       WebViewCache.setCategoriesCache(categories);
     }
@@ -171,7 +171,7 @@ export class PromptEditorPanel {
         content: this.initialContent || '',
         title: '',
         description: '',
-        category: this.initialCategory || 'General',
+        category: this.initialCategory || DEFAULT_CATEGORY,
       };
       promptJson = JSON.stringify(tempPrompt);
     }

--- a/test/helpers/prompt-factory.ts
+++ b/test/helpers/prompt-factory.ts
@@ -5,7 +5,7 @@
  * maintaining compatibility with the actual createPrompt() function.
  */
 
-import { createPrompt as baseCreatePrompt } from '../../src/models/prompt';
+import { createPrompt as baseCreatePrompt, DEFAULT_CATEGORY } from '../../src/models/prompt';
 import type { Prompt } from '../../src/models/prompt';
 
 /**
@@ -32,7 +32,7 @@ export function createPrompt(options: PromptOptions): Prompt {
   const prompt = baseCreatePrompt(
     options.title,
     options.content,
-    options.category || 'General',
+    options.category || DEFAULT_CATEGORY,
     options.description
   );
 

--- a/test/sync-edge-cases.test.ts
+++ b/test/sync-edge-cases.test.ts
@@ -544,4 +544,111 @@ describe('SyncService - Edge Cases', () => {
       }
     });
   });
+
+  describe('Default Category Handling', () => {
+    it('should default to DEFAULT_CATEGORY when remote prompt has null category', async () => {
+      // Arrange - Add cloud prompt with null category
+      const cloudPrompt = syncTestHelpers.addCloudPrompt({
+        local_id: 'prompt-null-cat',
+        title: 'Prompt With Null Category',
+        content: 'Test content',
+        category: null as unknown as string, // Simulate null from database
+        description: null,
+        prompt_order: null,
+        category_order: null,
+        content_hash: 'hash-123',
+        variables: [],
+        metadata: {
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+          usageCount: 0,
+        },
+        sync_metadata: null,
+        deleted_at: null,
+      });
+
+      // Act - Sync should download the prompt
+      const localPrompts = await promptService.listPrompts();
+      const result = await syncService.performSync(localPrompts, promptService);
+
+      // Assert - Downloaded prompt should have DEFAULT_CATEGORY
+      expect(result.stats.downloaded).toBe(1);
+
+      const finalPrompts = await promptService.listPrompts();
+      const downloadedPrompt = finalPrompts.find((p) => p.id === 'prompt-null-cat');
+
+      expect(downloadedPrompt).toBeDefined();
+      expect(downloadedPrompt!.category).toBe('General'); // DEFAULT_CATEGORY value
+    });
+
+    it('should default to DEFAULT_CATEGORY when remote prompt has undefined category', async () => {
+      // Arrange - Add cloud prompt with undefined category
+      const cloudPrompt = syncTestHelpers.addCloudPrompt({
+        local_id: 'prompt-undef-cat',
+        title: 'Prompt With Undefined Category',
+        content: 'Test content',
+        category: undefined as unknown as string, // Simulate undefined
+        description: null,
+        prompt_order: null,
+        category_order: null,
+        content_hash: 'hash-456',
+        variables: [],
+        metadata: {
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+          usageCount: 0,
+        },
+        sync_metadata: null,
+        deleted_at: null,
+      });
+
+      // Act
+      const localPrompts = await promptService.listPrompts();
+      const result = await syncService.performSync(localPrompts, promptService);
+
+      // Assert
+      expect(result.stats.downloaded).toBe(1);
+
+      const finalPrompts = await promptService.listPrompts();
+      const downloadedPrompt = finalPrompts.find((p) => p.id === 'prompt-undef-cat');
+
+      expect(downloadedPrompt).toBeDefined();
+      expect(downloadedPrompt!.category).toBe('General'); // DEFAULT_CATEGORY value
+    });
+
+    it('should default to DEFAULT_CATEGORY when remote prompt has empty string category', async () => {
+      // Arrange - Add cloud prompt with empty string category
+      const cloudPrompt = syncTestHelpers.addCloudPrompt({
+        local_id: 'prompt-empty-cat',
+        title: 'Prompt With Empty Category',
+        content: 'Test content',
+        category: '', // Empty string
+        description: null,
+        prompt_order: null,
+        category_order: null,
+        content_hash: 'hash-789',
+        variables: [],
+        metadata: {
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+          usageCount: 0,
+        },
+        sync_metadata: null,
+        deleted_at: null,
+      });
+
+      // Act
+      const localPrompts = await promptService.listPrompts();
+      const result = await syncService.performSync(localPrompts, promptService);
+
+      // Assert
+      expect(result.stats.downloaded).toBe(1);
+
+      const finalPrompts = await promptService.listPrompts();
+      const downloadedPrompt = finalPrompts.find((p) => p.id === 'prompt-empty-cat');
+
+      expect(downloadedPrompt).toBeDefined();
+      expect(downloadedPrompt!.category).toBe('General'); // DEFAULT_CATEGORY value
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fix null handling in `computeContentHash` to match web implementation
- Change conflict resolution from "keep both copies" to "latest wins"
- Ensure downloaded prompts never have null category

## Problem

1. **Hash mismatch**: Extension used `category.trim()` while web used `(category || "").trim()`, causing different hashes for the same content
2. **Duplicate accumulation**: Old conflict resolution created two copies per conflict, leading to prompt explosion

## Solution

1. **Hash alignment**: Both now use `(category || '').trim()` for null-safe handling
2. **Latest wins**: Conflicts now resolved by comparing timestamps - newer version wins, no duplicates created

## Test Plan

- [ ] Edit prompt on web, sync from extension → changes appear locally
- [x] Edit prompt in extension, sync → changes appear on web
- [x] Run sync multiple times on unchanged prompts → 0 downloads/uploads
- [ ] Create conflict (edit same prompt on both sides) → latest version wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)