### PR TITLE
feat(teams): add team mode with global prompt sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,12 @@
           "name": "Prompt Bank",
           "icon": "logo.svg",
           "when": "true"
+        },
+        {
+          "id": "promptBank.teamPromptsView",
+          "name": "Team Prompts",
+          "icon": "logo.svg",
+          "when": "promptBank.hasTeams"
         }
       ]
     },
@@ -149,6 +155,45 @@
         "command": "promptBank.restoreDeletedPrompts",
         "title": "♻️ Restore Deleted Prompts",
         "category": "Prompt Bank"
+      },
+      {
+        "command": "promptBank.syncTeamPrompts",
+        "title": "🔄 Sync Team Prompts",
+        "category": "Prompt Bank"
+      },
+      {
+        "command": "promptBank.refreshTeamTreeView",
+        "title": "Refresh Team Prompts",
+        "icon": "$(refresh)",
+        "commandPalette": true
+      },
+      {
+        "command": "promptBank.newTeamPrompt",
+        "title": "New Team Prompt",
+        "icon": "$(add)",
+        "category": "Prompt Bank"
+      },
+      {
+        "command": "promptBank.editTeamPromptFromTree",
+        "title": "Edit Team Prompt",
+        "commandPalette": false
+      },
+      {
+        "command": "promptBank.deleteTeamPromptFromTree",
+        "title": "Delete Team Prompt",
+        "icon": "$(trash)",
+        "commandPalette": false
+      },
+      {
+        "command": "promptBank.copyTeamPromptFromTree",
+        "title": "Copy Team Prompt",
+        "icon": "$(copy)",
+        "commandPalette": false
+      },
+      {
+        "command": "promptBank.copyTeamPromptToPersonal",
+        "title": "Copy to Personal Library",
+        "commandPalette": false
       }
     ],
     "menus": {
@@ -174,6 +219,16 @@
         {
           "command": "promptBank.newPrompt",
           "when": "view == promptBank.promptsView",
+          "group": "navigation@2"
+        },
+        {
+          "command": "promptBank.refreshTeamTreeView",
+          "when": "view == promptBank.teamPromptsView",
+          "group": "navigation@1"
+        },
+        {
+          "command": "promptBank.newTeamPrompt",
+          "when": "view == promptBank.teamPromptsView",
           "group": "navigation@2"
         }
       ],
@@ -234,6 +289,36 @@
           "command": "promptBank.shareCollectionFromTree",
           "when": "view == promptBank.promptsView && viewItem == promptBankCategory",
           "group": "1_modification@0"
+        },
+        {
+          "command": "promptBank.copyTeamPromptFromTree",
+          "when": "view == promptBank.teamPromptsView && viewItem =~ /^teamPrompt_/",
+          "group": "inline@1"
+        },
+        {
+          "command": "promptBank.copyTeamPromptFromTree",
+          "when": "view == promptBank.teamPromptsView && viewItem =~ /^teamPrompt_/",
+          "group": "1_actions@1"
+        },
+        {
+          "command": "promptBank.copyTeamPromptToPersonal",
+          "when": "view == promptBank.teamPromptsView && viewItem =~ /^teamPrompt_/",
+          "group": "1_actions@2"
+        },
+        {
+          "command": "promptBank.editTeamPromptFromTree",
+          "when": "view == promptBank.teamPromptsView && viewItem =~ /^teamPrompt_(editor|admin|owner)$/",
+          "group": "2_modification@1"
+        },
+        {
+          "command": "promptBank.deleteTeamPromptFromTree",
+          "when": "view == promptBank.teamPromptsView && viewItem =~ /^teamPrompt_(admin|owner)$/",
+          "group": "3_danger@1"
+        },
+        {
+          "command": "promptBank.newTeamPrompt",
+          "when": "view == promptBank.teamPromptsView && viewItem =~ /^team_(editor|admin|owner)$/",
+          "group": "0_create@1"
         }
       ]
     },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -273,14 +273,19 @@ export function registerCommands(
     }
   );
 
-  // Register new prompt command (tree view "+" button)
-  const newPromptCommand = vscode.commands.registerCommand('promptBank.newPrompt', async () => {
-    try {
-      await PromptEditorPanel.showForNewPrompt(context, '', promptService, treeProvider);
-    } catch (error) {
-      vscode.window.showErrorMessage(`Error creating new prompt: ${error}`);
+  // Register new prompt command (tree view "+" button, also used by copyToPersonal)
+  const newPromptCommand = vscode.commands.registerCommand(
+    'promptBank.newPrompt',
+    async (options?: { prefill?: { title?: string; content?: string; category?: string; description?: string } }) => {
+      try {
+        const content = options?.prefill?.content || '';
+        const category = options?.prefill?.category;
+        await PromptEditorPanel.showForNewPrompt(context, content, promptService, treeProvider, category);
+      } catch (error) {
+        vscode.window.showErrorMessage(`Error creating new prompt: ${error}`);
+      }
     }
-  });
+  );
 
   // Add all commands to context subscriptions
   context.subscriptions.push(

--- a/src/commands/teamCommands.ts
+++ b/src/commands/teamCommands.ts
@@ -1,0 +1,397 @@
+/**
+ * Team commands for team prompt management
+ *
+ * Commands for syncing, viewing, and managing team prompts.
+ * All operate on the global TeamService/TeamSyncService (not workspace-scoped).
+ */
+
+import * as vscode from 'vscode';
+import type { TeamService } from '../services/teamService';
+import type { TeamSyncService } from '../services/teamSyncService';
+import type { TeamTreeProvider, TeamPromptTreeItem, TeamTreeItem } from '../views/teamTreeProvider';
+import { canEdit, canDelete } from '../models/team';
+import { createPrompt } from '../models/prompt';
+
+/**
+ * Register all team-related commands
+ */
+export function registerTeamCommands(
+  _context: vscode.ExtensionContext,
+  teamService: TeamService,
+  teamSyncService: TeamSyncService,
+  teamTreeProvider: TeamTreeProvider
+): vscode.Disposable[] {
+  return [
+    // Sync all team prompts
+    vscode.commands.registerCommand('promptBank.syncTeamPrompts', async () => {
+      await syncTeamPromptsCommand(teamService, teamSyncService, teamTreeProvider);
+    }),
+
+    // Refresh team tree view
+    vscode.commands.registerCommand('promptBank.refreshTeamTreeView', async () => {
+      await refreshTeamTreeCommand(teamService, teamSyncService, teamTreeProvider);
+    }),
+
+    // Create a new prompt in a team
+    vscode.commands.registerCommand('promptBank.newTeamPrompt', async (item?: TeamTreeItem) => {
+      await newTeamPromptCommand(teamService, teamSyncService, teamTreeProvider, item);
+    }),
+
+    // Edit a team prompt
+    vscode.commands.registerCommand(
+      'promptBank.editTeamPromptFromTree',
+      async (item: TeamPromptTreeItem) => {
+        await editTeamPromptCommand(teamService, teamSyncService, teamTreeProvider, item);
+      }
+    ),
+
+    // Delete a team prompt
+    vscode.commands.registerCommand(
+      'promptBank.deleteTeamPromptFromTree',
+      async (item: TeamPromptTreeItem) => {
+        await deleteTeamPromptCommand(teamService, teamSyncService, teamTreeProvider, item);
+      }
+    ),
+
+    // Copy team prompt content to clipboard
+    vscode.commands.registerCommand(
+      'promptBank.copyTeamPromptFromTree',
+      async (item: TeamPromptTreeItem) => {
+        await vscode.env.clipboard.writeText(item.prompt.content);
+        vscode.window.showInformationMessage(`Copied "${item.prompt.title}" to clipboard`);
+      }
+    ),
+
+    // Fork team prompt to personal library
+    vscode.commands.registerCommand(
+      'promptBank.copyTeamPromptToPersonal',
+      async (item: TeamPromptTreeItem) => {
+        await copyToPersonalCommand(item);
+      }
+    ),
+  ];
+}
+
+/**
+ * Sync team prompts with progress indicator
+ */
+async function syncTeamPromptsCommand(
+  teamService: TeamService,
+  teamSyncService: TeamSyncService,
+  teamTreeProvider: TeamTreeProvider
+): Promise<void> {
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'Syncing team prompts...',
+      cancellable: false,
+    },
+    async () => {
+      try {
+        // Refresh team membership first
+        await teamService.refreshTeams();
+
+        // Sync all teams
+        const results = await teamSyncService.syncAllTeams();
+
+        // Update tree view with synced prompts
+        for (const team of teamService.getTeams()) {
+          const { storage } = await teamService.getTeamStorage(team.id);
+          const prompts = await storage.list();
+          teamTreeProvider.setTeamPrompts(team.id, prompts);
+        }
+
+        // Update context for view visibility
+        await vscode.commands.executeCommand(
+          'setContext',
+          'promptBank.hasTeams',
+          teamService.hasTeams()
+        );
+
+        // Report results
+        const totalDown = results.reduce((s, r) => s + r.downloaded, 0);
+        const totalUp = results.reduce((s, r) => s + r.uploaded, 0);
+        const totalErrors = results.reduce((s, r) => s + r.errors.length, 0);
+
+        if (totalErrors > 0) {
+          vscode.window.showWarningMessage(
+            `Team sync completed with ${totalErrors} error(s). Downloaded: ${totalDown}, Uploaded: ${totalUp}`
+          );
+        } else {
+          vscode.window.showInformationMessage(
+            `Team prompts synced. Downloaded: ${totalDown}, Uploaded: ${totalUp}`
+          );
+        }
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          `Team sync failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+}
+
+/**
+ * Refresh team tree (re-fetch teams + prompts)
+ */
+async function refreshTeamTreeCommand(
+  teamService: TeamService,
+  teamSyncService: TeamSyncService,
+  teamTreeProvider: TeamTreeProvider
+): Promise<void> {
+  await syncTeamPromptsCommand(teamService, teamSyncService, teamTreeProvider);
+}
+
+/**
+ * Create a new prompt in a team via quick input
+ */
+async function newTeamPromptCommand(
+  teamService: TeamService,
+  teamSyncService: TeamSyncService,
+  teamTreeProvider: TeamTreeProvider,
+  teamItem?: TeamTreeItem
+): Promise<void> {
+  let team = teamItem?.team;
+
+  // If no team specified, let user pick one
+  if (!team) {
+    const teams = teamService.getTeams().filter((t) => canEdit(t.role));
+    if (teams.length === 0) {
+      vscode.window.showWarningMessage('You need editor or higher role to create team prompts.');
+      return;
+    }
+
+    const picked = await vscode.window.showQuickPick(
+      teams.map((t) => ({ label: t.name, description: t.role, team: t })),
+      { placeHolder: 'Select a team to create the prompt in' }
+    );
+    if (!picked) {
+      return;
+    }
+    team = picked.team;
+  }
+
+  if (!canEdit(team.role)) {
+    vscode.window.showWarningMessage(
+      `You need editor or higher role in "${team.name}" to create prompts.`
+    );
+    return;
+  }
+
+  // Collect prompt data via input boxes
+  const title = await vscode.window.showInputBox({
+    prompt: 'Prompt title',
+    placeHolder: 'Enter a title for the team prompt',
+    validateInput: (v) => (v.trim() ? null : 'Title is required'),
+  });
+  if (!title) {
+    return;
+  }
+
+  const category = await vscode.window.showInputBox({
+    prompt: 'Category',
+    value: 'General',
+    placeHolder: 'Enter a category for the prompt',
+  });
+  if (category === undefined) {
+    return;
+  }
+
+  const description = await vscode.window.showInputBox({
+    prompt: 'Description (optional)',
+    placeHolder: 'Brief description of this prompt',
+  });
+  if (description === undefined) {
+    return;
+  }
+
+  const content = await vscode.window.showInputBox({
+    prompt: 'Prompt content',
+    placeHolder: 'Enter the prompt content',
+    validateInput: (v) => (v.trim() ? null : 'Content is required'),
+  });
+  if (!content) {
+    return;
+  }
+
+  try {
+    const prompt = createPrompt(
+      title.trim(),
+      content.trim(),
+      category.trim() || 'General',
+      description?.trim() || undefined
+    );
+    prompt.teamId = team.id;
+
+    const { storage } = await teamService.getTeamStorage(team.id);
+    await storage.save(prompt);
+
+    // Sync to upload the new prompt
+    await teamSyncService.syncTeam(team);
+
+    // Refresh tree
+    const prompts = await storage.list();
+    teamTreeProvider.setTeamPrompts(team.id, prompts);
+
+    vscode.window.showInformationMessage(`Created "${title}" in team "${team.name}"`);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Failed to create team prompt: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Edit a team prompt via quick input
+ */
+async function editTeamPromptCommand(
+  teamService: TeamService,
+  teamSyncService: TeamSyncService,
+  teamTreeProvider: TeamTreeProvider,
+  item: TeamPromptTreeItem
+): Promise<void> {
+  if (!canEdit(item.team.role)) {
+    vscode.window.showWarningMessage(
+      `You need editor or higher role in "${item.team.name}" to edit prompts.`
+    );
+    return;
+  }
+
+  // Edit fields via input boxes (pre-filled with current values)
+  const title = await vscode.window.showInputBox({
+    prompt: 'Prompt title',
+    value: item.prompt.title,
+    validateInput: (v) => (v.trim() ? null : 'Title is required'),
+  });
+  if (!title) {
+    return;
+  }
+
+  const content = await vscode.window.showInputBox({
+    prompt: 'Prompt content',
+    value: item.prompt.content,
+    validateInput: (v) => (v.trim() ? null : 'Content is required'),
+  });
+  if (!content) {
+    return;
+  }
+
+  const category = await vscode.window.showInputBox({
+    prompt: 'Category',
+    value: item.prompt.category,
+  });
+  if (category === undefined) {
+    return;
+  }
+
+  const description = await vscode.window.showInputBox({
+    prompt: 'Description (optional)',
+    value: item.prompt.description || '',
+  });
+  if (description === undefined) {
+    return;
+  }
+
+  try {
+    const trimmedDescription = description.trim();
+    const updated = {
+      ...item.prompt,
+      title: title.trim(),
+      content: content.trim(),
+      category: category.trim() || 'General',
+      metadata: {
+        ...item.prompt.metadata,
+        modified: new Date(),
+      },
+    };
+    if (trimmedDescription) {
+      updated.description = trimmedDescription;
+    } else {
+      delete updated.description;
+    }
+
+    const { storage } = await teamService.getTeamStorage(item.team.id);
+    await storage.save(updated);
+
+    // Sync to upload changes
+    await teamSyncService.syncTeam(item.team);
+
+    // Refresh tree
+    const prompts = await storage.list();
+    teamTreeProvider.setTeamPrompts(item.team.id, prompts);
+
+    vscode.window.showInformationMessage(`Updated "${title}" in team "${item.team.name}"`);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Failed to update team prompt: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Delete a team prompt
+ */
+async function deleteTeamPromptCommand(
+  teamService: TeamService,
+  teamSyncService: TeamSyncService,
+  teamTreeProvider: TeamTreeProvider,
+  item: TeamPromptTreeItem
+): Promise<void> {
+  if (!canDelete(item.team.role)) {
+    vscode.window.showWarningMessage(
+      `You need admin or higher role in "${item.team.name}" to delete prompts.`
+    );
+    return;
+  }
+
+  const confirm = await vscode.window.showWarningMessage(
+    `Delete "${item.prompt.title}" from team "${item.team.name}"?`,
+    { modal: true },
+    'Delete'
+  );
+
+  if (confirm !== 'Delete') {
+    return;
+  }
+
+  try {
+    const { storage } = await teamService.getTeamStorage(item.team.id);
+    await storage.delete(item.prompt.id);
+
+    // Re-sync to propagate the deletion
+    await teamSyncService.syncTeam(item.team);
+
+    // Update tree
+    const prompts = await storage.list();
+    teamTreeProvider.setTeamPrompts(item.team.id, prompts);
+
+    vscode.window.showInformationMessage(`Deleted "${item.prompt.title}" from ${item.team.name}`);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Failed to delete prompt: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Copy a team prompt to the personal library
+ */
+async function copyToPersonalCommand(item: TeamPromptTreeItem): Promise<void> {
+  try {
+    // Use the personal prompt creation command with pre-filled data
+    await vscode.commands.executeCommand('promptBank.newPrompt', {
+      prefill: {
+        title: `${item.prompt.title} (copy)`,
+        content: item.prompt.content,
+        category: item.prompt.category,
+        description: item.prompt.description,
+      },
+    });
+
+    vscode.window.showInformationMessage(`"${item.prompt.title}" copied to your personal library`);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Failed to copy prompt: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/src/commands/teamCommands.ts
+++ b/src/commands/teamCommands.ts
@@ -355,10 +355,13 @@ async function deleteTeamPromptCommand(
   }
 
   try {
-    const { storage } = await teamService.getTeamStorage(item.team.id);
+    const { storage, syncState } = await teamService.getTeamStorage(item.team.id);
     await storage.delete(item.prompt.id);
 
-    // Re-sync to propagate the deletion
+    // Mark as deleted in sync state so the engine won't re-download it
+    await syncState.markPromptAsDeleted(item.prompt.id);
+
+    // Re-sync to update sync state
     await teamSyncService.syncTeam(item.team);
 
     // Update tree

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,9 +5,11 @@ import { PromptTreeProvider, PromptDragAndDropController } from './views/promptT
 import { TreeCommands } from './commands/treeCommands';
 import { ContextMenuCommands } from './commands/contextMenuCommands';
 import { registerSyncCommands } from './commands/syncCommands';
+import { registerTeamCommands } from './commands/teamCommands';
 import { SupabaseClientManager } from './services/supabaseClient';
 import { WebViewCache } from './webview/WebViewCache';
 import { ServicesContainer, WorkspaceServices } from './services/servicesContainer';
+import { TeamTreeProvider } from './views/teamTreeProvider';
 
 // Global services container instance
 // Manages services per workspace with proper lifecycle
@@ -81,6 +83,61 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Refresh tree when prompts change
     context.subscriptions.push(treeView);
+
+    // ── Team Mode (global, not workspace-scoped) ──
+    // Initialize team services if user is authenticated
+    if (workspaceServices) {
+      const { teamService, teamSyncService } = await servicesContainer.initializeTeamServices(
+        context,
+        workspaceServices.auth
+      );
+
+      // Create team tree view
+      const teamTreeProvider = new TeamTreeProvider(teamService);
+      const teamTreeView = vscode.window.createTreeView('promptBank.teamPromptsView', {
+        treeDataProvider: teamTreeProvider,
+        showCollapseAll: true,
+      });
+      context.subscriptions.push(teamTreeView);
+
+      // Register team commands
+      const teamCmds = registerTeamCommands(
+        context,
+        teamService,
+        teamSyncService,
+        teamTreeProvider
+      );
+      context.subscriptions.push(...teamCmds);
+
+      // Background: fetch teams and set context for view visibility
+      teamService
+        .refreshTeams()
+        .then(async (teams) => {
+          await vscode.commands.executeCommand(
+            'setContext',
+            'promptBank.hasTeams',
+            teams.length > 0
+          );
+
+          // Auto-sync team prompts if user has teams
+          if (teams.length > 0) {
+            try {
+              await teamSyncService.syncAllTeams();
+              for (const team of teams) {
+                const { storage } = await teamService.getTeamStorage(team.id);
+                const prompts = await storage.list();
+                teamTreeProvider.setTeamPrompts(team.id, prompts);
+              }
+            } catch (err) {
+              console.warn('[Extension] Background team sync failed:', err);
+            }
+          }
+        })
+        .catch((err) => {
+          console.warn('[Extension] Failed to fetch teams:', err);
+          vscode.commands.executeCommand('setContext', 'promptBank.hasTeams', false);
+        });
+    }
 
     // Show activation message
     vscode.window.showInformationMessage('Prompt Bank is ready! 🚀');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,11 +85,20 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(treeView);
 
     // ── Team Mode (global, not workspace-scoped) ──
-    // Initialize team services if user is authenticated
-    if (workspaceServices) {
+    // Initialize team services regardless of workspace availability
+    {
+      // Use workspace auth if available, otherwise create a standalone AuthService
+      const teamAuthService = workspaceServices
+        ? workspaceServices.auth
+        : new (await import('./services/authService')).AuthService(
+            context,
+            context.extension.id.split('.')[0],
+            context.extension.id.split('.')[1]
+          );
+
       const { teamService, teamSyncService } = await servicesContainer.initializeTeamServices(
         context,
-        workspaceServices.auth
+        teamAuthService
       );
 
       // Create team tree view

--- a/src/models/prompt.ts
+++ b/src/models/prompt.ts
@@ -44,6 +44,9 @@ export interface Prompt {
 
   /** Metadata for analytics and future features */
   metadata: PromptMetadata;
+
+  /** Team ID if this is a team prompt (null/undefined = personal) */
+  teamId?: string;
 }
 
 /**

--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -1,0 +1,58 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Team Model
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Team roles in descending order of privilege */
+export type TeamRole = 'owner' | 'admin' | 'editor' | 'viewer';
+
+/** Role hierarchy for permission checks (higher = more privilege) */
+const ROLE_RANK: Record<TeamRole, number> = {
+  owner: 4,
+  admin: 3,
+  editor: 2,
+  viewer: 1,
+};
+
+/**
+ * Team data returned from the get-user-teams Edge Function
+ */
+export interface Team {
+  /** Unique team identifier */
+  id: string;
+
+  /** Team display name */
+  name: string;
+
+  /** Optional team description */
+  description: string | null;
+
+  /** Current user's role in this team */
+  role: TeamRole;
+
+  /** Number of team members */
+  memberCount: number;
+
+  /** When the team was created */
+  createdAt: string;
+}
+
+/**
+ * Check if a role has at least the given minimum privilege level
+ */
+export function hasMinRole(userRole: TeamRole, minRole: TeamRole): boolean {
+  return ROLE_RANK[userRole] >= ROLE_RANK[minRole];
+}
+
+/**
+ * Check if the user can create or edit prompts in this team (editor+)
+ */
+export function canEdit(role: TeamRole): boolean {
+  return hasMinRole(role, 'editor');
+}
+
+/**
+ * Check if the user can delete prompts in this team (admin+)
+ */
+export function canDelete(role: TeamRole): boolean {
+  return hasMinRole(role, 'admin');
+}

--- a/src/services/sync/index.ts
+++ b/src/services/sync/index.ts
@@ -1,0 +1,9 @@
+export { SyncEngine, SYNC_ERROR_CODES } from './syncEngine';
+export { PersonalTransport } from './personalTransport';
+export { TeamTransport } from './teamTransport';
+export type {
+  SyncTransport,
+  SyncEngineConfig,
+  LocalPromptStore,
+  WritePermission,
+} from './syncTransport';

--- a/src/services/sync/personalTransport.ts
+++ b/src/services/sync/personalTransport.ts
@@ -1,0 +1,354 @@
+/**
+ * PersonalTransport — Personal mode I/O for SyncEngine
+ *
+ * Wraps all personal-mode edge function calls extracted from SyncService:
+ * sync-prompt, get-user-prompts, delete-prompt, restore-prompt,
+ * get-user-quota, register-workspace.
+ */
+
+import * as vscode from 'vscode';
+import type { Prompt } from '../../models/prompt';
+import type {
+  RemotePrompt,
+  PromptSyncInfo,
+  SyncConflictError,
+  UserQuota,
+} from '../../models/syncState';
+import { SyncConflictType } from '../../models/syncState';
+import { SupabaseClientManager } from '../supabaseClient';
+import type { AuthService } from '../authService';
+import type { WorkspaceMetadataService } from '../workspaceMetadataService';
+import { computeContentHash } from '../../utils/contentHash';
+import { getDeviceInfo } from '../../utils/deviceId';
+import type { SyncTransport, WritePermission } from './syncTransport';
+
+export class PersonalTransport implements SyncTransport {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly authService: AuthService,
+    private readonly workspaceMetadataService: WorkspaceMetadataService
+  ) {}
+
+  private async getWorkspaceId(): Promise<string> {
+    return this.workspaceMetadataService.getOrCreateWorkspaceId();
+  }
+
+  private getWorkspaceName(): string {
+    const folders = vscode.workspace.workspaceFolders;
+    return folders?.[0]?.name ?? 'Unnamed Workspace';
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // SyncTransport Implementation
+  // ────────────────────────────────────────────────────────────────────────────
+
+  async fetchRemotePrompts(includeDeleted = false): Promise<readonly RemotePrompt[]> {
+    const supabase = SupabaseClientManager.get();
+    const workspaceId = await this.getWorkspaceId();
+
+    try {
+      const { data, error } = await supabase.functions.invoke('get-user-prompts', {
+        body: {
+          workspaceId,
+          includeDeleted,
+        },
+      });
+
+      if (error) {
+        const errorMessage = error.message || String(error);
+        const errorContext = (error as { context?: { status?: number } }).context;
+
+        if (
+          errorContext?.status === 401 ||
+          errorMessage.toLowerCase().includes('invalid jwt') ||
+          errorMessage.toLowerCase().includes('unauthorized')
+        ) {
+          console.warn('[PersonalTransport] Detected invalid JWT error. Clearing tokens...');
+          await this.authService.clearInvalidTokens();
+          throw new Error(
+            'Your session has expired. Please try syncing again to sign in with a new session.'
+          );
+        }
+
+        throw error;
+      }
+
+      return (data as { prompts: RemotePrompt[] }).prompts;
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('session has expired')) {
+          throw error;
+        }
+        throw new Error(`Failed to fetch remote prompts: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async uploadPrompt(
+    prompt: Prompt,
+    syncInfo?: PromptSyncInfo
+  ): Promise<{ cloudId: string; version: number }> {
+    const supabase = SupabaseClientManager.get();
+    const contentHash = computeContentHash(prompt);
+    const deviceInfo = await getDeviceInfo(this.context);
+    const workspaceId = await this.getWorkspaceId();
+
+    const body = {
+      workspaceId,
+      cloudId: syncInfo?.cloudId,
+      expectedVersion: syncInfo?.version,
+      contentHash: contentHash,
+      local_id: prompt.id,
+      title: prompt.title,
+      content: prompt.content,
+      description: prompt.description || null,
+      category: prompt.category,
+      prompt_order: prompt.order || null,
+      category_order: prompt.categoryOrder || null,
+      variables: prompt.variables,
+      metadata: {
+        created: prompt.metadata.created.toISOString(),
+        modified: prompt.metadata.modified.toISOString(),
+        usageCount: prompt.metadata.usageCount,
+        lastUsed: prompt.metadata.lastUsed?.toISOString(),
+        context: prompt.metadata.context,
+      },
+      sync_metadata: {
+        lastModifiedDeviceId: deviceInfo.id,
+        lastModifiedDeviceName: deviceInfo.name,
+      },
+    };
+
+    try {
+      const { data, error } = await supabase.functions.invoke('sync-prompt', {
+        body: body,
+      });
+
+      if (error) {
+        const errorMessage = error.message || String(error);
+        const errorContext = (error as { context?: { status?: number } }).context;
+
+        if (
+          errorContext?.status === 401 ||
+          errorMessage.toLowerCase().includes('invalid jwt') ||
+          errorMessage.toLowerCase().includes('unauthorized')
+        ) {
+          console.warn(
+            '[PersonalTransport] Detected invalid JWT error during upload. Clearing tokens...'
+          );
+          await this.authService.clearInvalidTokens();
+          throw new Error(
+            'Your session has expired. Please try syncing again to sign in with a new session.'
+          );
+        }
+
+        // Check for 409 conflict - Need to parse Response object to get error details
+        if (errorContext?.status === 409) {
+          const response = errorContext as unknown as Response;
+          let responseBody: any;
+
+          try {
+            const clonedResponse = response.clone();
+            responseBody = await clonedResponse.json();
+          } catch (parseError) {
+            console.warn('[PersonalTransport] Failed to parse 409 response body:', parseError);
+            throw new Error('Sync conflict detected but response body could not be parsed');
+          }
+
+          const conflictError = new Error(responseBody?.message || 'Sync conflict');
+          (conflictError as any).context = {
+            status: 409,
+            error: responseBody?.error,
+            details: responseBody?.details,
+          };
+          throw conflictError;
+        }
+
+        throw error;
+      }
+
+      return data as { cloudId: string; version: number };
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('session has expired')) {
+          throw error;
+        }
+        if ((error as any).context) {
+          throw error;
+        }
+        throw new Error(`Failed to upload prompt: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async deletePrompt(cloudId: string): Promise<void> {
+    const supabase = SupabaseClientManager.get();
+    const deviceInfo = await getDeviceInfo(this.context);
+    const workspaceId = await this.getWorkspaceId();
+
+    const { error } = await supabase.functions.invoke('delete-prompt', {
+      body: { workspaceId, cloudId, deviceId: deviceInfo.id },
+    });
+
+    if (error) {
+      const errorContext = (error as { context?: { status?: number } }).context;
+      if (errorContext?.status === 404) {
+        console.info(`[PersonalTransport] Prompt ${cloudId} already deleted in cloud`);
+        return;
+      }
+      throw new Error(`Failed to delete prompt: ${error.message}`);
+    }
+  }
+
+  parseSyncConflictError(error: unknown): SyncConflictError | null {
+    if (!(error instanceof Error)) {
+      return null;
+    }
+
+    const errorContext = (
+      error as { context?: { status?: number; error?: string; details?: unknown } }
+    ).context;
+
+    if (errorContext?.status !== 409) {
+      return null;
+    }
+
+    // NEW FORMAT: Server returns specific error code
+    if (
+      errorContext.error &&
+      Object.values(SyncConflictType).includes(errorContext.error as SyncConflictType)
+    ) {
+      const result: SyncConflictError = {
+        code: errorContext.error as SyncConflictType,
+        message: error.message || 'Sync conflict',
+        ...(errorContext.details
+          ? { details: errorContext.details as NonNullable<SyncConflictError['details']> }
+          : {}),
+      };
+
+      return result;
+    }
+
+    // LEGACY FORMAT: Server returns generic 'conflict' message
+    if (error.message?.includes('conflict') || errorContext.error === 'conflict') {
+      console.warn(
+        '[PersonalTransport] Received legacy 409 conflict format. Assuming PROMPT_DELETED.'
+      );
+      return {
+        code: SyncConflictType.PROMPT_DELETED,
+        message: 'Conflict detected (legacy format)',
+      };
+    }
+
+    return null;
+  }
+
+  getWritePermission(): WritePermission {
+    return { canUpload: true, canDelete: true };
+  }
+
+  async getIdentity(): Promise<string> {
+    // For personal mode, device name comes from sync state (set during init)
+    // We use the device info utility directly
+    const deviceInfo = await getDeviceInfo(this.context);
+    return deviceInfo.name;
+  }
+
+  async checkQuota(uploadCount: number, uploadSizeBytes: number): Promise<void> {
+    const quota = await this.fetchUserQuota();
+
+    if (quota.promptCount + uploadCount > quota.promptLimit) {
+      const overage = uploadCount - (quota.promptLimit - quota.promptCount);
+      throw new Error(
+        `Cannot sync: would exceed limit by ${overage} prompts. ` +
+          `Delete ${overage} prompts and try again.`
+      );
+    }
+
+    if (quota.storageBytes + uploadSizeBytes > quota.storageLimit) {
+      const overageMB = (
+        (quota.storageBytes + uploadSizeBytes - quota.storageLimit) / 1048576
+      ).toFixed(1);
+      throw new Error(
+        `Cannot sync: would exceed 10 MB storage limit by ${overageMB} MB. ` +
+          `Delete some prompts and try again.`
+      );
+    }
+
+    if (quota.percentageUsed > 90) {
+      void vscode.window.showWarningMessage(
+        `You're using ${quota.percentageUsed}% of your storage quota. ` +
+          `Consider deleting old prompts.`
+      );
+    }
+  }
+
+  async registerWorkspace(): Promise<void> {
+    try {
+      const supabase = SupabaseClientManager.get();
+      const workspaceId = await this.getWorkspaceId();
+      const workspaceName = this.getWorkspaceName();
+      const deviceInfo = await getDeviceInfo(this.context);
+
+      const { error } = await supabase.functions.invoke('register-workspace', {
+        body: {
+          workspaceId,
+          workspaceName,
+          deviceName: deviceInfo.name,
+        },
+      });
+
+      if (error) {
+        console.warn('[PersonalTransport] Failed to register workspace:', error.message);
+      }
+    } catch (error) {
+      console.warn(
+        '[PersonalTransport] Error registering workspace:',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Personal-only helpers
+  // ────────────────────────────────────────────────────────────────────────────
+
+  private async fetchUserQuota(): Promise<UserQuota> {
+    const supabase = SupabaseClientManager.get();
+
+    try {
+      const { data, error } = await supabase.functions.invoke('get-user-quota', {
+        body: {},
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      return data as UserQuota;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to fetch user quota: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Restore a soft-deleted prompt in the cloud (used by SyncService public API)
+   */
+  async restorePrompt(cloudId: string): Promise<void> {
+    const supabase = SupabaseClientManager.get();
+    const workspaceId = await this.getWorkspaceId();
+
+    const { error } = await supabase.functions.invoke('restore-prompt', {
+      body: { workspaceId, cloudId },
+    });
+
+    if (error) {
+      throw new Error(`Failed to restore prompt: ${error.message}`);
+    }
+  }
+}

--- a/src/services/sync/syncEngine.ts
+++ b/src/services/sync/syncEngine.ts
@@ -1,0 +1,676 @@
+/**
+ * SyncEngine — Shared three-way merge algorithm with conflict resolution
+ *
+ * Extracted from SyncService to be reused by both personal and team sync.
+ * The engine owns the merge algorithm and conflict resolution logic.
+ * Mode-specific I/O is delegated to a SyncTransport implementation.
+ *
+ * CRITICAL FEATURES:
+ * - Content-hash conflict detection (prevents same-second edit bugs)
+ * - Optimistic locking (prevents race conditions)
+ * - Conflict resolution creates two copies — never silently discards work
+ */
+
+import type { Prompt, TemplateVariable, FileContext } from '../../models/prompt';
+import { DEFAULT_CATEGORY } from '../../models/prompt';
+import type {
+  SyncPlan,
+  SyncResult,
+  RemotePrompt,
+  PromptSyncInfo,
+} from '../../models/syncState';
+import { SyncConflictType } from '../../models/syncState';
+import type { SyncStateStorage } from '../../storage/syncStateStorage';
+import { computeContentHash, matchesHash } from '../../utils/contentHash';
+import type { SyncTransport, SyncEngineConfig, LocalPromptStore } from './syncTransport';
+
+/**
+ * Internal error codes used for sync retry logic
+ */
+const SYNC_ERROR_CODES = {
+  /** Thrown when a sync conflict requires retrying the entire sync operation */
+  CONFLICT_RETRY: 'sync_conflict_retry',
+} as const;
+
+export { SYNC_ERROR_CODES };
+
+export class SyncEngine {
+  constructor(
+    private readonly transport: SyncTransport,
+    private readonly syncStateStorage: SyncStateStorage,
+    private readonly config: SyncEngineConfig
+  ) {}
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Three-Way Merge Algorithm
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Compute sync plan using three-way merge algorithm
+   *
+   * Compares: local state, remote state, last synced state (via content hash)
+   *
+   * @param local - Local prompts
+   * @param remote - Remote prompts from Supabase
+   * @param lastSync - Last sync timestamp (undefined on first sync)
+   * @param promptSyncMap - Map of promptId -> sync info
+   * @returns Sync plan with uploads, downloads, and conflicts
+   */
+  computeSyncPlan(
+    local: readonly Prompt[],
+    remote: readonly RemotePrompt[],
+    lastSync: Date | undefined,
+    promptSyncMap: Readonly<Record<string, PromptSyncInfo>>
+  ): SyncPlan {
+    const plan: SyncPlan = {
+      toUpload: [] as Prompt[],
+      toDownload: [] as RemotePrompt[],
+      toDelete: [] as Array<{ cloudId: string }>,
+      conflicts: [],
+      toAssignLocalId: [] as Array<{ remote: RemotePrompt; generatedLocalId: string }>,
+      toDeleteLocally: [] as Array<{ localPromptId: string; cloudId: string; deletedAt: string }>,
+    };
+
+    // Build lookup maps
+    const localMap = new Map(local.map((p) => [p.id, p]));
+    const remoteMap = new Map<string, RemotePrompt>();
+
+    // Build reverse lookup map: cloudId -> localPromptId (O(n) once, enables O(1) lookups)
+    const cloudIdToLocalId = new Map<string, string>();
+    for (const [promptId, info] of Object.entries(promptSyncMap)) {
+      if (info.cloudId) {
+        cloudIdToLocalId.set(info.cloudId, promptId);
+      }
+    }
+
+    // Map ACTIVE remote prompts only (exclude soft-deleted)
+    for (const remotePrompt of remote) {
+      if (!remotePrompt.deleted_at) {
+        remoteMap.set(remotePrompt.cloud_id, remotePrompt);
+      }
+    }
+
+    // Detect locally deleted prompts (exist in sync state but not in local)
+    const localIds = new Set(local.map((p) => p.id));
+    const deletedLocally = new Set<string>();
+
+    for (const [promptId, info] of Object.entries(promptSyncMap)) {
+      if (!localIds.has(promptId) && !info.isDeleted) {
+        deletedLocally.add(info.cloudId);
+      }
+    }
+
+    // Process local prompts
+    for (const prompt of local) {
+      const syncInfo = promptSyncMap[prompt.id];
+      const cloudId = syncInfo?.cloudId;
+      let remotePrompt = cloudId ? remoteMap.get(cloudId) : undefined;
+
+      // On first sync, try matching by local_id if cloudId not available
+      if (!remotePrompt && !cloudId) {
+        // First sync - try matching by local_id
+        const matchedByLocalId = remote.find((r) => r.local_id === prompt.id && !r.deleted_at);
+        if (matchedByLocalId) {
+          remotePrompt = matchedByLocalId;
+          // Update remoteMap for subsequent lookups
+          remoteMap.set(matchedByLocalId.cloud_id, matchedByLocalId);
+        }
+      }
+
+      if (!remotePrompt) {
+        // Check if deleted remotely (must have cloudId to check)
+        const remoteDeleted = cloudId
+          ? remote.find((r) => r.cloud_id === cloudId && r.deleted_at)
+          : undefined;
+
+        if (remoteDeleted) {
+          // DELETE-MODIFY CONFLICT: Remote was deleted, but local copy still exists.
+          if (syncInfo?.isDeleted) {
+            // Corrupted state: syncInfo says deleted but prompt still exists locally
+            plan.toUpload.push(prompt);
+          } else {
+            const remoteDeletedAt = new Date(remoteDeleted.deleted_at!);
+            const localModifiedAt = prompt.metadata.modified;
+
+            if (localModifiedAt > remoteDeletedAt) {
+              // Local was modified AFTER remote deletion - keep local version
+              plan.toUpload.push(prompt);
+            }
+            // else: Local was NOT modified after remote deletion - honor the deletion
+          }
+        } else {
+          // New local prompt - upload
+          plan.toUpload.push(prompt);
+        }
+        continue;
+      }
+
+      // Prompt exists both locally and remotely
+      const localModified = prompt.metadata.modified;
+      const remoteModified = new Date(remotePrompt.updated_at);
+
+      // Compute content hashes
+      const localHash = computeContentHash(prompt);
+      const remoteHash = remotePrompt.content_hash;
+      const lastSyncHash = syncInfo?.lastSyncedContentHash;
+
+      // Determine if this is first sync for this prompt
+      const isFirstSyncForPrompt = !syncInfo || !lastSyncHash;
+
+      if (isFirstSyncForPrompt && !lastSync) {
+        // TRUE FIRST SYNC - Check content hash for conflicts
+        if (localHash !== remoteHash) {
+          plan.conflicts.push({ local: prompt, remote: remotePrompt });
+        } else if (localModified > remoteModified) {
+          plan.toUpload.push(prompt);
+        }
+      } else {
+        // SUBSEQUENT SYNCS - Three-way merge
+        const localChangedSinceSync = lastSyncHash ? !matchesHash(prompt, lastSyncHash) : true;
+        const remoteChangedSinceSync = lastSyncHash ? remoteHash !== lastSyncHash : true;
+
+        if (localChangedSinceSync && remoteChangedSinceSync) {
+          // CONFLICT - both modified since last sync
+          if (localHash !== remoteHash) {
+            plan.conflicts.push({ local: prompt, remote: remotePrompt });
+          }
+        } else if (localChangedSinceSync) {
+          plan.toUpload.push(prompt);
+        } else if (remoteChangedSinceSync) {
+          plan.toDownload.push(remotePrompt);
+        }
+      }
+    }
+
+    // Detect remote deletions
+    const cloudIdsQueuedForUpload = new Set(
+      (plan.toUpload as Prompt[])
+        .map((p) => {
+          const syncInfo = promptSyncMap[p.id];
+          return syncInfo?.cloudId;
+        })
+        .filter((id): id is string => id !== undefined)
+    );
+
+    for (const remotePrompt of remote) {
+      if (!remotePrompt.deleted_at) continue;
+
+      if (cloudIdsQueuedForUpload.has(remotePrompt.cloud_id)) {
+        continue;
+      }
+
+      const localPromptId = cloudIdToLocalId.get(remotePrompt.cloud_id);
+
+      if (localPromptId && localMap.has(localPromptId)) {
+        const syncInfo = promptSyncMap[localPromptId];
+
+        if (!syncInfo?.isDeleted) {
+          plan.toDeleteLocally.push({
+            localPromptId,
+            cloudId: remotePrompt.cloud_id,
+            deletedAt: remotePrompt.deleted_at!,
+          });
+        }
+      }
+    }
+
+    // Process deletions (locally-deleted prompts that need cloud soft-delete)
+    if (this.config.handleCloudDeletion) {
+      for (const cloudId of deletedLocally) {
+        plan.toDelete.push({ cloudId });
+      }
+    }
+
+    // Find new remote prompts not in local (but not deleted locally)
+    for (const remotePrompt of remote) {
+      if (remotePrompt.deleted_at) continue;
+
+      const localPromptId = cloudIdToLocalId.get(remotePrompt.cloud_id);
+      if (!localPromptId || !localMap.has(localPromptId)) {
+        if (!deletedLocally.has(remotePrompt.cloud_id)) {
+          // Phase 5: Check if web-created (no local_id)
+          if (this.config.handleWebCreatedPrompts && !remotePrompt.local_id) {
+            const generatedLocalId = this.generateNewId();
+            plan.toAssignLocalId.push({ remote: remotePrompt, generatedLocalId });
+          } else {
+            plan.toDownload.push(remotePrompt);
+          }
+        }
+      }
+    }
+
+    return plan;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Conflict Resolution
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Generate a new unique ID for prompts
+   *
+   * Format: prompt_{timestamp}_{9-char-random}
+   */
+  generateNewId(): string {
+    const timestamp = Date.now();
+    const randomSuffix = Math.random().toString(36).slice(2, 11);
+    return `prompt_${timestamp}_${randomSuffix}`;
+  }
+
+  /**
+   * Resolve conflict by creating two separate prompts with device names
+   *
+   * CRITICAL BEHAVIOR:
+   * 1. The original local prompt will be DELETED from prompts.json (by caller)
+   * 2. Two NEW prompts are created with NEW IDs (neither reuses the original ID)
+   * 3. localCopy is uploaded as NEW cloud prompt
+   * 4. remoteCopy is linked to EXISTING cloud prompt (avoids 409 conflicts)
+   * 5. Strips existing conflict suffixes to prevent nesting
+   */
+  async resolveConflict(
+    local: Prompt,
+    remote: RemotePrompt
+  ): Promise<readonly [Prompt, Prompt]> {
+    // Strip existing conflict suffixes to prevent nesting
+    const suffixPattern = / \(from .+ - \w{3} \d{1,2}\)$/;
+    const baseTitle = local.title.replace(suffixPattern, '');
+
+    const localDeviceName = await this.transport.getIdentity();
+
+    // Parse remote device name from sync_metadata
+    const remoteSyncMeta = remote.sync_metadata as { lastModifiedDeviceName?: string } | null;
+    const remoteDeviceName = remoteSyncMeta?.lastModifiedDeviceName || 'Unknown Device';
+
+    const formatDateTime = (date: Date): string => {
+      const months = [
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      ];
+      const hours = date.getHours().toString().padStart(2, '0');
+      const minutes = date.getMinutes().toString().padStart(2, '0');
+      return `${months[date.getMonth()]} ${date.getDate()} ${hours}:${minutes}`;
+    };
+
+    // Create two separate prompts with NEW IDs for both
+    const localCopy: Prompt = {
+      ...local,
+      id: this.generateNewId(),
+      title: `${baseTitle} (from ${localDeviceName} - ${formatDateTime(local.metadata.modified)})`,
+    };
+
+    const remoteCopy: Prompt = this.convertRemoteToLocal(remote);
+    remoteCopy.id = this.generateNewId();
+    remoteCopy.title = `${baseTitle} (from ${remoteDeviceName} - ${formatDateTime(new Date(remote.updated_at))})`;
+
+    return [localCopy, remoteCopy] as const;
+  }
+
+  /**
+   * Convert remote prompt to local Prompt format
+   */
+  convertRemoteToLocal(remote: RemotePrompt, generatedLocalId?: string): Prompt {
+    interface MetadataJSON {
+      created: string | number | Date;
+      modified: string | number | Date;
+      usageCount: number;
+      lastUsed?: string | number | Date;
+      context?: FileContext;
+    }
+    const metadata = remote.metadata as MetadataJSON;
+    const variables = (remote.variables as TemplateVariable[]) || [];
+
+    const localId = generatedLocalId ?? remote.local_id ?? this.generateNewId();
+
+    const prompt: Prompt = {
+      id: localId,
+      title: remote.title,
+      content: remote.content,
+      category: remote.category || DEFAULT_CATEGORY,
+      variables: variables,
+      metadata: {
+        created: new Date(metadata.created),
+        modified: new Date(metadata.modified),
+        usageCount: metadata.usageCount || 0,
+      },
+    };
+
+    if (remote.description) {
+      prompt.description = remote.description;
+    }
+    if (remote.prompt_order !== null && remote.prompt_order !== undefined) {
+      prompt.order = remote.prompt_order;
+    }
+    if (remote.category_order !== null && remote.category_order !== undefined) {
+      prompt.categoryOrder = remote.category_order;
+    }
+    if (metadata.lastUsed) {
+      prompt.metadata.lastUsed = new Date(metadata.lastUsed);
+    }
+    if (metadata.context) {
+      prompt.metadata.context = metadata.context;
+    }
+
+    return prompt;
+  }
+
+  /**
+   * Upload prompt with intelligent conflict resolution
+   *
+   * Handles three types of conflicts:
+   * 1. PROMPT_DELETED - Cloud prompt was soft-deleted -> Upload as NEW prompt
+   * 2. VERSION_CONFLICT - Version mismatch -> Throw error to retry entire sync
+   * 3. OPTIMISTIC_LOCK_CONFLICT - Concurrent modification -> Throw error to retry
+   */
+  async uploadWithConflictHandling(
+    prompt: Prompt,
+    syncInfo?: PromptSyncInfo
+  ): Promise<{ cloudId: string; version: number }> {
+    try {
+      return await this.transport.uploadPrompt(prompt, syncInfo);
+    } catch (uploadError) {
+      const conflictError = this.transport.parseSyncConflictError(uploadError);
+
+      if (!conflictError) {
+        throw uploadError;
+      }
+
+      switch (conflictError.code) {
+        case SyncConflictType.PROMPT_DELETED:
+          console.info(
+            `[SyncEngine] Prompt ${prompt.id} was deleted in cloud (cloudId: ${syncInfo?.cloudId}). ` +
+              `Creating new cloud prompt.`
+          );
+          return await this.transport.uploadPrompt(prompt); // No syncInfo = new prompt
+
+        case SyncConflictType.VERSION_CONFLICT:
+        case SyncConflictType.OPTIMISTIC_LOCK_CONFLICT:
+          console.warn(
+            `[SyncEngine] ${conflictError.code} for prompt ${prompt.id}. ` +
+              `Expected v${conflictError.details?.expectedVersion}, ` +
+              `actual v${conflictError.details?.actualVersion}. ` +
+              `Retrying sync...`
+          );
+          throw new Error(SYNC_ERROR_CODES.CONFLICT_RETRY);
+
+        default:
+          console.error(`[SyncEngine] Unknown conflict type: ${conflictError.code}`);
+          throw new Error(SYNC_ERROR_CODES.CONFLICT_RETRY);
+      }
+    }
+  }
+
+  /**
+   * Calculate total upload size for quota check
+   */
+  calculateUploadSize(prompts: unknown[]): number {
+    return prompts.reduce((total: number, prompt) => {
+      const size = Buffer.byteLength(JSON.stringify(prompt), 'utf8');
+      return total + size;
+    }, 0);
+  }
+
+  /**
+   * Execute sync plan with comprehensive error handling
+   *
+   * @param plan - Sync plan computed by three-way merge
+   * @param localStore - Local prompt store for saving/deleting prompts
+   * @returns Sync result with statistics
+   */
+  async executeSyncPlan(plan: SyncPlan, localStore: LocalPromptStore): Promise<SyncResult> {
+    const result: SyncResult = {
+      stats: { uploaded: 0, downloaded: 0, deleted: 0, conflicts: 0, duration: 0 },
+    };
+
+    const startTime = Date.now();
+    const writePerms = this.transport.getWritePermission();
+
+    try {
+      // 1. Handle conflicts first (create local duplicates)
+      for (const conflict of plan.conflicts) {
+        const localPrompt = conflict.local as Prompt;
+        const [localCopy, remoteCopy] = await this.resolveConflict(localPrompt, conflict.remote);
+
+        // Save both conflict copies locally with device-specific names
+        await localStore.savePromptDirectly(localCopy);
+        await localStore.savePromptDirectly(remoteCopy);
+
+        // Delete the original LOCAL prompt from prompts.json
+        await localStore.deletePromptById(localPrompt.id);
+
+        // Mark the original local prompt as deleted in sync state
+        await this.syncStateStorage.markPromptAsDeleted(localPrompt.id);
+
+        // Compute content hashes for both copies
+        const localHash = computeContentHash(localCopy);
+        const remoteHash = computeContentHash(remoteCopy);
+
+        // Upload localCopy as a NEW cloud prompt (if we have write permission)
+        if (writePerms.canUpload) {
+          try {
+            const localCloudId = await this.transport.uploadPrompt(localCopy);
+            await this.syncStateStorage.setPromptSyncInfo(localCopy.id, {
+              cloudId: localCloudId.cloudId,
+              lastSyncedContentHash: localHash,
+              lastSyncedAt: new Date(),
+              version: localCloudId.version,
+            });
+          } catch (uploadError) {
+            console.warn(
+              `[SyncEngine] Failed to upload local conflict copy "${localCopy.title}" (${localCopy.id}). ` +
+                `Will retry on next sync.`,
+              uploadError
+            );
+          }
+        }
+
+        // Link remoteCopy to the EXISTING cloud prompt
+        try {
+          await this.syncStateStorage.setPromptSyncInfo(remoteCopy.id, {
+            cloudId: conflict.remote.cloud_id,
+            lastSyncedContentHash: remoteHash,
+            lastSyncedAt: new Date(),
+            version: conflict.remote.version,
+          });
+        } catch (linkError) {
+          console.warn(
+            `[SyncEngine] Failed to link remote conflict copy to cloud_id ${conflict.remote.cloud_id}. ` +
+              `Attempting to upload as new prompt.`,
+            linkError
+          );
+          if (writePerms.canUpload) {
+            try {
+              const remoteCloudId = await this.transport.uploadPrompt(remoteCopy);
+              await this.syncStateStorage.setPromptSyncInfo(remoteCopy.id, {
+                cloudId: remoteCloudId.cloudId,
+                lastSyncedContentHash: remoteHash,
+                lastSyncedAt: new Date(),
+                version: remoteCloudId.version,
+              });
+            } catch (fallbackError) {
+              console.warn(
+                `[SyncEngine] Failed to upload remote conflict copy "${remoteCopy.title}" (${remoteCopy.id}). ` +
+                  `Will retry on next sync.`,
+                fallbackError
+              );
+            }
+          }
+        }
+
+        result.stats.conflicts++;
+      }
+
+      // 2. Handle remote deletions (prompts deleted on web UI)
+      for (const { localPromptId, cloudId, deletedAt } of plan.toDeleteLocally) {
+        try {
+          const deleted = await localStore.deletePromptById(localPromptId);
+
+          if (deleted) {
+            await this.syncStateStorage.setPromptSyncInfo(localPromptId, {
+              cloudId,
+              lastSyncedContentHash: '',
+              lastSyncedAt: new Date(),
+              version: 0,
+              isDeleted: true,
+              deletedAt: new Date(deletedAt),
+            });
+            result.stats.deleted++;
+          }
+        } catch (error) {
+          console.error(`[SyncEngine] Failed to delete local prompt "${localPromptId}":`, error);
+        }
+      }
+
+      // 3. Process cloud deletions (soft-delete cloud prompts that were deleted locally)
+      if (this.config.handleCloudDeletion && writePerms.canDelete) {
+        for (const { cloudId } of plan.toDelete) {
+          await this.transport.deletePrompt(cloudId);
+
+          const promptId = await this.syncStateStorage.findLocalPromptId(cloudId);
+          if (promptId) {
+            await this.syncStateStorage.markPromptAsDeleted(promptId);
+          }
+
+          result.stats.deleted++;
+        }
+      }
+
+      // 4. Upload prompts (local changes -> cloud)
+      if (writePerms.canUpload) {
+        for (const promptUnknown of plan.toUpload) {
+          const prompt = promptUnknown as Prompt;
+          const syncInfo = await this.syncStateStorage.getPromptSyncInfo(prompt.id);
+
+          // Handle corrupted sync state: syncInfo points to soft-deleted cloud prompt
+          if (syncInfo?.cloudId && syncInfo.isDeleted) {
+            await this.syncStateStorage.setPromptSyncInfo(prompt.id, {
+              cloudId: '',
+              lastSyncedContentHash: '',
+              lastSyncedAt: new Date(),
+              version: 0,
+              isDeleted: false,
+            });
+
+            const uploaded = await this.transport.uploadPrompt(prompt);
+            const contentHash = computeContentHash(prompt);
+            await this.syncStateStorage.setPromptSyncInfo(prompt.id, {
+              cloudId: uploaded.cloudId,
+              lastSyncedContentHash: contentHash,
+              lastSyncedAt: new Date(),
+              version: uploaded.version,
+            });
+
+            result.stats.uploaded++;
+            continue;
+          }
+
+          // Normal upload with conflict handling (optimistic locking)
+          const uploaded = await this.uploadWithConflictHandling(prompt, syncInfo ?? undefined);
+          const contentHash = computeContentHash(prompt);
+          await this.syncStateStorage.setPromptSyncInfo(prompt.id, {
+            cloudId: uploaded.cloudId,
+            lastSyncedContentHash: contentHash,
+            lastSyncedAt: new Date(),
+            version: uploaded.version,
+            isDeleted: false,
+          });
+
+          result.stats.uploaded++;
+        }
+      }
+
+      // 5. Download prompts (cloud changes -> local)
+      for (const remotePrompt of plan.toDownload) {
+        const localPrompt = this.convertRemoteToLocal(remotePrompt);
+        await localStore.savePromptDirectly(localPrompt);
+
+        const contentHash = computeContentHash(localPrompt);
+        await this.syncStateStorage.setPromptSyncInfo(localPrompt.id, {
+          cloudId: remotePrompt.cloud_id,
+          lastSyncedContentHash: contentHash,
+          lastSyncedAt: new Date(),
+          version: remotePrompt.version,
+        });
+
+        result.stats.downloaded++;
+      }
+
+      // 6. Handle web-created prompts (download + upload local_id)
+      if (this.config.handleWebCreatedPrompts) {
+        for (const { remote, generatedLocalId } of plan.toAssignLocalId) {
+          const localPrompt = this.convertRemoteToLocal(remote, generatedLocalId);
+          await localStore.savePromptDirectly(localPrompt);
+
+          const syncInfo: PromptSyncInfo = {
+            cloudId: remote.cloud_id,
+            lastSyncedContentHash: remote.content_hash,
+            lastSyncedAt: new Date(),
+            version: remote.version,
+          };
+
+          if (writePerms.canUpload) {
+            try {
+              const uploaded = await this.transport.uploadPrompt(localPrompt, syncInfo);
+              await this.syncStateStorage.setPromptSyncInfo(localPrompt.id, {
+                cloudId: uploaded.cloudId,
+                lastSyncedContentHash: computeContentHash(localPrompt),
+                lastSyncedAt: new Date(),
+                version: uploaded.version,
+              });
+              result.stats.downloaded++;
+            } catch (error) {
+              const conflictError = this.transport.parseSyncConflictError(error);
+              if (conflictError) {
+                console.warn(
+                  `[SyncEngine] ${conflictError.code} while assigning local_id to "${localPrompt.title}". ` +
+                    `Local copy preserved, will retry on next sync.`
+                );
+              } else {
+                console.warn(
+                  `[SyncEngine] Failed to update local_id for "${localPrompt.title}": ` +
+                    `${error instanceof Error ? error.message : String(error)}`
+                );
+              }
+
+              await this.syncStateStorage.setPromptSyncInfo(localPrompt.id, {
+                cloudId: remote.cloud_id,
+                lastSyncedContentHash: '',
+                lastSyncedAt: new Date(),
+                version: remote.version,
+              });
+              result.stats.downloaded++;
+            }
+          } else {
+            // No write permission — just save locally with sync info
+            await this.syncStateStorage.setPromptSyncInfo(localPrompt.id, {
+              cloudId: remote.cloud_id,
+              lastSyncedContentHash: computeContentHash(localPrompt),
+              lastSyncedAt: new Date(),
+              version: remote.version,
+            });
+            result.stats.downloaded++;
+          }
+        }
+      }
+
+      result.stats.duration = Date.now() - startTime;
+      return result;
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      if (errorMessage.includes('network') || errorMessage.includes('fetch')) {
+        throw new Error('Unable to sync - check your internet connection');
+      } else if (errorMessage.includes('auth') || errorMessage.includes('unauthorized')) {
+        throw new Error('Authentication expired - please sign in again');
+      } else if (errorMessage.includes('quota') || errorMessage.includes('limit')) {
+        throw error;
+      } else if (
+        errorMessage.includes('conflict') ||
+        errorMessage === SYNC_ERROR_CODES.CONFLICT_RETRY
+      ) {
+        throw new Error(SYNC_ERROR_CODES.CONFLICT_RETRY);
+      }
+
+      throw new Error(`Sync failed: ${errorMessage}`);
+    }
+  }
+}

--- a/src/services/sync/syncTransport.ts
+++ b/src/services/sync/syncTransport.ts
@@ -1,0 +1,82 @@
+/**
+ * Transport interface for SyncEngine
+ *
+ * Defines the contract between the sync engine (merge algorithm + conflict resolution)
+ * and mode-specific I/O (personal vs team). Each transport handles its own edge functions,
+ * role checks, and workspace scoping.
+ */
+
+import type { Prompt } from '../../models/prompt';
+import type {
+  RemotePrompt,
+  PromptSyncInfo,
+  SyncConflictError,
+} from '../../models/syncState';
+
+/**
+ * Write permission descriptor returned by transport
+ */
+export interface WritePermission {
+  readonly canUpload: boolean;
+  readonly canDelete: boolean;
+}
+
+/**
+ * Transport interface between SyncEngine and mode-specific I/O
+ *
+ * Personal transport: calls sync-prompt, get-user-prompts, delete-prompt, etc.
+ * Team transport: calls sync-team-prompt, get-team-prompts with role gating.
+ */
+export interface SyncTransport {
+  /** Fetch remote prompts from cloud */
+  fetchRemotePrompts(includeDeleted: boolean): Promise<readonly RemotePrompt[]>;
+
+  /** Upload a prompt to cloud with optimistic locking */
+  uploadPrompt(
+    prompt: Prompt,
+    syncInfo?: PromptSyncInfo
+  ): Promise<{ cloudId: string; version: number }>;
+
+  /** Soft-delete a prompt in cloud */
+  deletePrompt(cloudId: string): Promise<void>;
+
+  /** Parse 409 responses into SyncConflictError */
+  parseSyncConflictError(error: unknown): SyncConflictError | null;
+
+  /** Get write permission for the current user/role */
+  getWritePermission(): WritePermission;
+
+  /** Get attribution name for conflict copies (device name) */
+  getIdentity(): Promise<string>;
+
+  /** Pre-flight quota check (personal only, optional) */
+  checkQuota?(uploadCount: number, uploadSizeBytes: number): Promise<void>;
+
+  /** Register workspace in cloud (personal only, optional) */
+  registerWorkspace?(): Promise<void>;
+}
+
+/**
+ * Configuration flags for SyncEngine behavior differences
+ */
+export interface SyncEngineConfig {
+  /** Handle web-created prompts (toAssignLocalId phase) — personal only */
+  handleWebCreatedPrompts: boolean;
+
+  /** Handle cloud deletion (toDelete phase for locally-deleted prompts) — personal only */
+  handleCloudDeletion: boolean;
+
+  /** Run pre-flight quota check before uploading — personal only */
+  checkQuota: boolean;
+}
+
+/**
+ * Local prompt store interface for SyncEngine to save/delete prompts locally
+ *
+ * PromptService satisfies this for personal mode.
+ * FileStorageProvider.save()/delete() get wrapped for team mode.
+ */
+export interface LocalPromptStore {
+  savePromptDirectly(prompt: Prompt): Promise<Prompt>;
+  deletePromptById(id: string): Promise<boolean>;
+}

--- a/src/services/sync/teamTransport.ts
+++ b/src/services/sync/teamTransport.ts
@@ -1,0 +1,215 @@
+/**
+ * TeamTransport — Team mode I/O for SyncEngine
+ *
+ * Wraps all team-mode edge function calls:
+ * sync-team-prompt, get-team-prompts with role gating.
+ */
+
+import * as vscode from 'vscode';
+import type { Prompt } from '../../models/prompt';
+import type {
+  RemotePrompt,
+  PromptSyncInfo,
+  SyncConflictError,
+} from '../../models/syncState';
+import { SyncConflictType } from '../../models/syncState';
+import { SupabaseClientManager } from '../supabaseClient';
+import type { AuthService } from '../authService';
+import type { TeamRole } from '../../models/team';
+import { canEdit, canDelete } from '../../models/team';
+import { computeContentHash } from '../../utils/contentHash';
+import { getDeviceInfo } from '../../utils/deviceId';
+import type { SyncTransport, WritePermission } from './syncTransport';
+
+export class TeamTransport implements SyncTransport {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly authService: AuthService,
+    private readonly teamId: string,
+    private readonly teamRole: TeamRole
+  ) {}
+
+  async fetchRemotePrompts(includeDeleted = false): Promise<readonly RemotePrompt[]> {
+    const supabase = SupabaseClientManager.get();
+
+    const { data, error } = await supabase.functions.invoke('get-team-prompts', {
+      body: { teamId: this.teamId, includeDeleted },
+    });
+
+    if (error) {
+      const errorContext = (error as { context?: { status?: number } }).context;
+      if (errorContext?.status === 401) {
+        await this.authService.clearInvalidTokens();
+        throw new Error('Your session has expired. Please sign in again.');
+      }
+      if (errorContext?.status === 403) {
+        throw new Error('You are not a member of this team.');
+      }
+      throw new Error(`Failed to fetch team prompts: ${error.message}`);
+    }
+
+    return (data as { prompts: RemotePrompt[] }).prompts || [];
+  }
+
+  async uploadPrompt(
+    prompt: Prompt,
+    syncInfo?: PromptSyncInfo
+  ): Promise<{ cloudId: string; version: number }> {
+    const supabase = SupabaseClientManager.get();
+    const contentHash = computeContentHash(prompt);
+    const deviceInfo = await getDeviceInfo(this.context);
+
+    const body = {
+      teamId: this.teamId,
+      cloudId: syncInfo?.cloudId,
+      expectedVersion: syncInfo?.version,
+      contentHash,
+      local_id: prompt.id,
+      title: prompt.title,
+      content: prompt.content,
+      description: prompt.description || null,
+      category: prompt.category,
+      prompt_order: prompt.order || null,
+      category_order: prompt.categoryOrder || null,
+      variables: prompt.variables,
+      metadata: {
+        created: prompt.metadata.created.toISOString(),
+        modified: prompt.metadata.modified.toISOString(),
+        usageCount: prompt.metadata.usageCount,
+        lastUsed: prompt.metadata.lastUsed?.toISOString(),
+        context: prompt.metadata.context,
+      },
+      sync_metadata: {
+        lastModifiedDeviceId: deviceInfo.id,
+        lastModifiedDeviceName: deviceInfo.name,
+      },
+    };
+
+    try {
+      const { data, error } = await supabase.functions.invoke('sync-team-prompt', {
+        body,
+      });
+
+      if (error) {
+        const errorContext = (error as { context?: { status?: number } }).context;
+
+        if (errorContext?.status === 401) {
+          await this.authService.clearInvalidTokens();
+          throw new Error('Session expired during team sync.');
+        }
+
+        if (errorContext?.status === 403) {
+          const insufficientRoleError = new Error('Insufficient permissions to edit team prompts.');
+          (insufficientRoleError as any).context = {
+            status: 403,
+            error: 'INSUFFICIENT_ROLE',
+          };
+          throw insufficientRoleError;
+        }
+
+        // Check for 409 conflict
+        if (errorContext?.status === 409) {
+          const response = errorContext as unknown as Response;
+          let responseBody: any;
+
+          try {
+            const clonedResponse = response.clone();
+            responseBody = await clonedResponse.json();
+          } catch {
+            throw new Error('Sync conflict detected but response body could not be parsed');
+          }
+
+          const conflictError = new Error(responseBody?.message || 'Sync conflict');
+          (conflictError as any).context = {
+            status: 409,
+            error: responseBody?.error,
+            details: responseBody?.details,
+          };
+          throw conflictError;
+        }
+
+        throw new Error(`Team prompt upload failed: ${error.message}`);
+      }
+
+      const uploadData = data as { cloudId: string; version: number };
+      return { cloudId: uploadData.cloudId, version: uploadData.version };
+    } catch (error) {
+      if (error instanceof Error) {
+        if ((error as any).context) {
+          throw error;
+        }
+        if (
+          error.message.includes('Session expired') ||
+          error.message.includes('Insufficient permissions')
+        ) {
+          throw error;
+        }
+        throw new Error(`Team prompt upload failed: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async deletePrompt(cloudId: string): Promise<void> {
+    // Team mode doesn't currently support cloud deletion from extension
+    // (handled by admin through web UI)
+    console.warn(`[TeamTransport] Cloud deletion not supported for team prompts (cloudId: ${cloudId})`);
+  }
+
+  parseSyncConflictError(error: unknown): SyncConflictError | null {
+    if (!(error instanceof Error)) {
+      return null;
+    }
+
+    const errorContext = (
+      error as { context?: { status?: number; error?: string; details?: unknown } }
+    ).context;
+
+    if (!errorContext) {
+      return null;
+    }
+
+    // Handle 403 INSUFFICIENT_ROLE as a special conflict type
+    if (errorContext.status === 403 && errorContext.error === 'INSUFFICIENT_ROLE') {
+      return null; // Let the caller handle permission errors directly
+    }
+
+    if (errorContext.status !== 409) {
+      return null;
+    }
+
+    if (
+      errorContext.error &&
+      Object.values(SyncConflictType).includes(errorContext.error as SyncConflictType)
+    ) {
+      return {
+        code: errorContext.error as SyncConflictType,
+        message: error.message || 'Sync conflict',
+        ...(errorContext.details
+          ? { details: errorContext.details as NonNullable<SyncConflictError['details']> }
+          : {}),
+      };
+    }
+
+    if (error.message?.includes('conflict') || errorContext.error === 'conflict') {
+      return {
+        code: SyncConflictType.PROMPT_DELETED,
+        message: 'Conflict detected (legacy format)',
+      };
+    }
+
+    return null;
+  }
+
+  getWritePermission(): WritePermission {
+    return {
+      canUpload: canEdit(this.teamRole),
+      canDelete: canDelete(this.teamRole),
+    };
+  }
+
+  async getIdentity(): Promise<string> {
+    const deviceInfo = await getDeviceInfo(this.context);
+    return deviceInfo.name;
+  }
+}

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -42,10 +42,14 @@ export class TeamService {
    */
   async refreshTeams(): Promise<Team[]> {
     const token = await this.authService.getValidAccessToken();
-    if (!token) {
+    const refreshToken = await this.authService.getRefreshToken();
+    if (!token || !refreshToken) {
       this.teams = [];
       return this.teams;
     }
+
+    // Set auth session before calling edge function (client uses persistSession: false)
+    await SupabaseClientManager.setSession(token, refreshToken);
 
     const supabase = SupabaseClientManager.get();
 

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -1,0 +1,133 @@
+/**
+ * Team Service - Extension-level (global) team data manager
+ *
+ * Manages team membership data and per-team storage instances.
+ * This service is NOT workspace-scoped — it lives at the extension level
+ * and stores data in VS Code's globalStoragePath.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import type { Team, TeamRole } from '../models/team';
+import { SupabaseClientManager } from './supabaseClient';
+import { AuthService } from './authService';
+import { FileStorageProvider } from '../storage/fileStorage';
+import { SyncStateStorage } from '../storage/syncStateStorage';
+
+/**
+ * Per-team storage instances
+ */
+interface TeamStorageBundle {
+  storage: FileStorageProvider;
+  syncState: SyncStateStorage;
+}
+
+/**
+ * TeamService manages team membership and per-team storage.
+ *
+ * Created once at extension activation using context.globalStoragePath.
+ * Shared across all workspaces.
+ */
+export class TeamService {
+  private teams: Team[] = [];
+  private teamStorageMap = new Map<string, TeamStorageBundle>();
+
+  constructor(
+    private readonly globalStoragePath: string,
+    private readonly authService: AuthService
+  ) {}
+
+  /**
+   * Fetch the user's teams from the backend and cache them
+   */
+  async refreshTeams(): Promise<Team[]> {
+    const token = await this.authService.getValidAccessToken();
+    if (!token) {
+      this.teams = [];
+      return this.teams;
+    }
+
+    const supabase = SupabaseClientManager.get();
+
+    const { data, error } = await supabase.functions.invoke('get-user-teams', {});
+
+    if (error) {
+      const errorContext = (error as { context?: { status?: number } }).context;
+      if (errorContext?.status === 401) {
+        console.warn('[TeamService] Auth expired during team fetch');
+        this.teams = [];
+        return this.teams;
+      }
+      throw new Error(`Failed to fetch teams: ${error.message}`);
+    }
+
+    this.teams = ((data as { teams: Team[] }).teams || []).map((t) => ({
+      id: t.id,
+      name: t.name,
+      description: t.description,
+      role: t.role as TeamRole,
+      memberCount: t.memberCount,
+      createdAt: t.createdAt,
+    }));
+
+    return this.teams;
+  }
+
+  /**
+   * Get cached teams (call refreshTeams first for fresh data)
+   */
+  getTeams(): readonly Team[] {
+    return this.teams;
+  }
+
+  /**
+   * Get a specific team by ID
+   */
+  getTeam(teamId: string): Team | undefined {
+    return this.teams.find((t) => t.id === teamId);
+  }
+
+  /**
+   * Whether the user has any teams
+   */
+  hasTeams(): boolean {
+    return this.teams.length > 0;
+  }
+
+  /**
+   * Get or create storage instances for a team
+   *
+   * Storage is created at: {globalStoragePath}/teams/{teamId}/
+   */
+  async getTeamStorage(teamId: string): Promise<TeamStorageBundle> {
+    if (this.teamStorageMap.has(teamId)) {
+      return this.teamStorageMap.get(teamId)!;
+    }
+
+    const teamStoragePath = path.join(this.globalStoragePath, 'teams', teamId);
+
+    // Ensure directory exists
+    await fs.mkdir(teamStoragePath, { recursive: true });
+
+    const storage = new FileStorageProvider({ storagePath: teamStoragePath });
+    await storage.initialize();
+
+    // SyncStateStorage defaults to {root}/.vscode/prompt-bank/ but accepts
+    // an explicit storagePath override for non-workspace usage
+    const syncState = new SyncStateStorage(teamStoragePath, {
+      storagePath: teamStoragePath,
+    });
+
+    const bundle: TeamStorageBundle = { storage, syncState };
+    this.teamStorageMap.set(teamId, bundle);
+    return bundle;
+  }
+
+  /**
+   * Dispose all team storage instances
+   */
+  async dispose(): Promise<void> {
+    this.teams = [];
+    this.teamStorageMap.clear();
+  }
+}

--- a/src/services/teamSyncService.ts
+++ b/src/services/teamSyncService.ts
@@ -1,0 +1,391 @@
+/**
+ * Team Sync Service - Extension-level (global) sync for team prompts
+ *
+ * Implements last-writer-wins sync for team prompts across multiple members.
+ * Unlike personal SyncService (three-way merge), team sync uses a simpler
+ * strategy since multiple users collaborate on the same prompt library.
+ *
+ * Key differences from personal sync:
+ * - Last-writer-wins conflict resolution (remote always wins on conflict)
+ * - Role-based write checks (editor+ to upload, admin+ to delete)
+ * - No workspace ID binding (team prompts are global)
+ * - Single sync cycle for all teams
+ */
+
+import * as vscode from 'vscode';
+import type { Prompt, TemplateVariable } from '../models/prompt';
+import type { Team } from '../models/team';
+import { canEdit } from '../models/team';
+import type { RemotePrompt, PromptSyncInfo } from '../models/syncState';
+import { SupabaseClientManager } from './supabaseClient';
+import { AuthService } from './authService';
+import { TeamService } from './teamService';
+import { computeContentHash, matchesHash } from '../utils/contentHash';
+import { getDeviceInfo } from '../utils/deviceId';
+
+/**
+ * Mutable sync state for team prompts (simpler than personal SyncState)
+ */
+interface TeamSyncState {
+  promptSyncMap: Record<string, PromptSyncInfo>;
+  lastSyncedAt?: Date;
+}
+
+/**
+ * Result of a team sync operation
+ */
+export interface TeamSyncResult {
+  teamId: string;
+  teamName: string;
+  downloaded: number;
+  uploaded: number;
+  deleted: number;
+  conflicts: number;
+  errors: string[];
+}
+
+export class TeamSyncService {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly authService: AuthService,
+    private readonly teamService: TeamService
+  ) {}
+
+  /**
+   * Sync prompts for all teams the user belongs to
+   */
+  async syncAllTeams(): Promise<TeamSyncResult[]> {
+    const teams = this.teamService.getTeams();
+    if (teams.length === 0) {
+      return [];
+    }
+
+    const results: TeamSyncResult[] = [];
+
+    for (const team of teams) {
+      try {
+        const result = await this.syncTeam(team);
+        results.push(result);
+      } catch (error) {
+        results.push({
+          teamId: team.id,
+          teamName: team.name,
+          downloaded: 0,
+          uploaded: 0,
+          deleted: 0,
+          conflicts: 0,
+          errors: [error instanceof Error ? error.message : String(error)],
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Sync prompts for a single team
+   */
+  async syncTeam(team: Team): Promise<TeamSyncResult> {
+    const result: TeamSyncResult = {
+      teamId: team.id,
+      teamName: team.name,
+      downloaded: 0,
+      uploaded: 0,
+      deleted: 0,
+      conflicts: 0,
+      errors: [],
+    };
+
+    const { storage, syncState: syncStateStorage } = await this.teamService.getTeamStorage(team.id);
+
+    // 1. Fetch local prompts and sync state
+    const localPrompts = await storage.list();
+    const savedState = await syncStateStorage.getSyncState();
+
+    // Build mutable team sync state from persisted state
+    const syncState: TeamSyncState = {
+      promptSyncMap: savedState ? { ...savedState.promptSyncMap } : {},
+    };
+    if (savedState?.lastSyncedAt) {
+      syncState.lastSyncedAt = savedState.lastSyncedAt;
+    }
+
+    // 2. Fetch remote team prompts
+    const remotePrompts = await this.fetchTeamPrompts(team.id, true);
+
+    // 3. Compute sync plan (last-writer-wins)
+    const plan = this.computeTeamSyncPlan(localPrompts, remotePrompts, syncState, team);
+
+    // 4. Download remote changes to local
+    for (const remote of plan.toDownload) {
+      try {
+        const localPrompt = this.remoteToLocal(remote, team.id);
+        await storage.save(localPrompt);
+        syncState.promptSyncMap[localPrompt.id] = {
+          cloudId: remote.cloud_id,
+          version: remote.version,
+          lastSyncedContentHash: remote.content_hash,
+          lastSyncedAt: new Date(),
+          isDeleted: false,
+        };
+        result.downloaded++;
+      } catch (err) {
+        result.errors.push(`Download failed for ${remote.cloud_id}: ${err}`);
+      }
+    }
+
+    // 5. Upload local changes (editor+ only)
+    if (canEdit(team.role)) {
+      for (const local of plan.toUpload) {
+        try {
+          const syncInfo = syncState.promptSyncMap[local.id];
+          const uploadResult = await this.uploadTeamPrompt(local, team.id, syncInfo);
+          syncState.promptSyncMap[local.id] = {
+            cloudId: uploadResult.cloudId,
+            version: uploadResult.version,
+            lastSyncedContentHash: computeContentHash(local),
+            lastSyncedAt: new Date(),
+            isDeleted: false,
+          };
+          result.uploaded++;
+        } catch (err) {
+          result.errors.push(`Upload failed for ${local.id}: ${err}`);
+        }
+      }
+    }
+
+    // 6. Delete locally prompts that were deleted remotely
+    for (const deletion of plan.toDeleteLocally) {
+      try {
+        await storage.delete(deletion.localPromptId);
+        if (syncState.promptSyncMap[deletion.localPromptId]) {
+          syncState.promptSyncMap[deletion.localPromptId].isDeleted = true;
+        }
+        result.deleted++;
+      } catch (err) {
+        result.errors.push(`Local delete failed for ${deletion.localPromptId}: ${err}`);
+      }
+    }
+
+    // 7. Save updated sync state - persist via syncStateStorage
+    // We save the promptSyncMap back through the storage layer
+    // For team sync, we only need the promptSyncMap persisted
+    syncState.lastSyncedAt = new Date();
+    if (savedState) {
+      // Update the existing state with our mutable changes
+      const updatedState = {
+        ...savedState,
+        promptSyncMap: Object.freeze(syncState.promptSyncMap),
+        lastSyncedAt: syncState.lastSyncedAt,
+      };
+      await syncStateStorage.saveSyncState(updatedState);
+    }
+
+    return result;
+  }
+
+  /**
+   * Compute team sync plan using last-writer-wins strategy
+   *
+   * Remote always wins on conflict since team prompts are collaborative.
+   */
+  private computeTeamSyncPlan(
+    localPrompts: readonly Prompt[],
+    remotePrompts: readonly RemotePrompt[],
+    syncState: TeamSyncState,
+    team: Team
+  ) {
+    const plan = {
+      toDownload: [] as RemotePrompt[],
+      toUpload: [] as Prompt[],
+      toDeleteLocally: [] as Array<{ localPromptId: string; cloudId: string }>,
+    };
+
+    const localMap = new Map(localPrompts.map((p) => [p.id, p]));
+
+    // Build cloudId -> localId lookup from sync state
+    const cloudIdToLocalId = new Map<string, string>();
+    for (const [promptId, info] of Object.entries(syncState.promptSyncMap)) {
+      if (info.cloudId) {
+        cloudIdToLocalId.set(info.cloudId, promptId);
+      }
+    }
+
+    // Active remote prompts (not deleted)
+    const activeRemote = remotePrompts.filter((r) => !r.deleted_at);
+    const deletedRemote = remotePrompts.filter((r) => r.deleted_at);
+
+    // Process active remote prompts
+    for (const remote of activeRemote) {
+      const localId = cloudIdToLocalId.get(remote.cloud_id);
+      const local = localId ? localMap.get(localId) : undefined;
+
+      if (!local) {
+        // New remote prompt or previously unknown - download
+        plan.toDownload.push(remote);
+        continue;
+      }
+
+      // Both exist - check if remote is newer (last-writer-wins)
+      const syncInfo = syncState.promptSyncMap[local.id];
+      const lastSyncHash = syncInfo?.lastSyncedContentHash;
+      const remoteHash = remote.content_hash;
+
+      const localChanged = lastSyncHash ? !matchesHash(local, lastSyncHash) : false;
+      const remoteChanged = lastSyncHash ? remoteHash !== lastSyncHash : false;
+
+      if (remoteChanged && localChanged) {
+        // Conflict - remote wins (last-writer-wins for team prompts)
+        plan.toDownload.push(remote);
+      } else if (remoteChanged) {
+        // Only remote changed - download
+        plan.toDownload.push(remote);
+      } else if (localChanged && canEdit(team.role)) {
+        // Only local changed and user can edit - upload
+        plan.toUpload.push(local);
+      }
+      // else: no changes - skip
+    }
+
+    // Process remote deletions - delete locally if known
+    for (const remote of deletedRemote) {
+      const localId = cloudIdToLocalId.get(remote.cloud_id);
+      if (localId && localMap.has(localId)) {
+        plan.toDeleteLocally.push({ localPromptId: localId, cloudId: remote.cloud_id });
+      }
+    }
+
+    // Process local-only prompts (no cloudId in sync state) - upload as new
+    if (canEdit(team.role)) {
+      for (const local of localPrompts) {
+        const syncInfo = syncState.promptSyncMap[local.id];
+        if (!syncInfo?.cloudId) {
+          plan.toUpload.push(local);
+        }
+      }
+    }
+
+    return plan;
+  }
+
+  /**
+   * Fetch team prompts from the backend
+   */
+  private async fetchTeamPrompts(teamId: string, includeDeleted = false): Promise<RemotePrompt[]> {
+    const supabase = SupabaseClientManager.get();
+
+    const { data, error } = await supabase.functions.invoke('get-team-prompts', {
+      body: { teamId, includeDeleted },
+    });
+
+    if (error) {
+      const errorContext = (error as { context?: { status?: number } }).context;
+      if (errorContext?.status === 401) {
+        await this.authService.clearInvalidTokens();
+        throw new Error('Your session has expired. Please sign in again.');
+      }
+      if (errorContext?.status === 403) {
+        throw new Error('You are not a member of this team.');
+      }
+      throw new Error(`Failed to fetch team prompts: ${error.message}`);
+    }
+
+    return (data as { prompts: RemotePrompt[] }).prompts || [];
+  }
+
+  /**
+   * Upload a prompt to a team
+   */
+  private async uploadTeamPrompt(
+    prompt: Prompt,
+    teamId: string,
+    syncInfo?: PromptSyncInfo
+  ): Promise<{ cloudId: string; version: number }> {
+    const supabase = SupabaseClientManager.get();
+    const contentHash = computeContentHash(prompt);
+    const deviceInfo = await getDeviceInfo(this.context);
+
+    const body = {
+      teamId,
+      cloudId: syncInfo?.cloudId,
+      expectedVersion: syncInfo?.version,
+      contentHash,
+      local_id: prompt.id,
+      title: prompt.title,
+      content: prompt.content,
+      description: prompt.description || null,
+      category: prompt.category,
+      prompt_order: prompt.order || null,
+      category_order: prompt.categoryOrder || null,
+      variables: prompt.variables,
+      sync_metadata: {
+        lastModifiedDeviceId: deviceInfo.id,
+        lastModifiedDeviceName: deviceInfo.name,
+      },
+    };
+
+    const { data, error } = await supabase.functions.invoke('sync-team-prompt', {
+      body,
+    });
+
+    if (error) {
+      const errorContext = (error as { context?: { status?: number } }).context;
+      if (errorContext?.status === 401) {
+        await this.authService.clearInvalidTokens();
+        throw new Error('Session expired during team sync.');
+      }
+      if (errorContext?.status === 403) {
+        throw new Error('Insufficient permissions to edit team prompts.');
+      }
+      throw new Error(`Team prompt upload failed: ${error.message}`);
+    }
+
+    const uploadData = data as { cloudId: string; version: number };
+    return { cloudId: uploadData.cloudId, version: uploadData.version };
+  }
+
+  /**
+   * Convert a remote prompt to local Prompt format
+   */
+  private remoteToLocal(remote: RemotePrompt, teamId: string): Prompt {
+    const meta = remote.metadata as { usageCount?: number; lastUsed?: string } | undefined;
+
+    const metadata: Prompt['metadata'] = {
+      created: new Date(remote.created_at),
+      modified: new Date(remote.updated_at),
+      usageCount: meta?.usageCount || 0,
+    };
+    if (meta?.lastUsed) {
+      metadata.lastUsed = new Date(meta.lastUsed);
+    }
+
+    const prompt: Prompt = {
+      id: remote.local_id || remote.cloud_id,
+      title: remote.title,
+      content: remote.content,
+      category: remote.category || 'General',
+      variables: (remote.variables as TemplateVariable[]) || [],
+      teamId,
+      metadata,
+    };
+
+    if (remote.description) {
+      prompt.description = remote.description;
+    }
+    if (remote.prompt_order != null) {
+      prompt.order = remote.prompt_order;
+    }
+    if (remote.category_order != null) {
+      prompt.categoryOrder = remote.category_order;
+    }
+
+    return prompt;
+  }
+
+  /**
+   * Dispose resources
+   */
+  async dispose(): Promise<void> {
+    // No persistent resources to clean up
+  }
+}

--- a/src/services/teamSyncService.ts
+++ b/src/services/teamSyncService.ts
@@ -1,35 +1,25 @@
 /**
  * Team Sync Service - Extension-level (global) sync for team prompts
  *
- * Implements last-writer-wins sync for team prompts across multiple members.
- * Unlike personal SyncService (three-way merge), team sync uses a simpler
- * strategy since multiple users collaborate on the same prompt library.
+ * Delegates to SyncEngine (shared three-way merge + conflict resolution) +
+ * TeamTransport (team-mode I/O) for the actual sync work.
  *
- * Key differences from personal sync:
- * - Last-writer-wins conflict resolution (remote always wins on conflict)
- * - Role-based write checks (editor+ to upload, admin+ to delete)
+ * Key difference from personal sync:
+ * - Role-based write checks via TeamTransport.getWritePermission()
  * - No workspace ID binding (team prompts are global)
- * - Single sync cycle for all teams
+ * - No quota check, no workspace registration
+ * - Uses the SAME three-way merge algorithm (no more last-writer-wins)
  */
 
 import * as vscode from 'vscode';
-import type { Prompt, TemplateVariable } from '../models/prompt';
+import type { Prompt } from '../models/prompt';
 import type { Team } from '../models/team';
-import { canEdit } from '../models/team';
-import type { RemotePrompt, PromptSyncInfo } from '../models/syncState';
-import { SupabaseClientManager } from './supabaseClient';
 import { AuthService } from './authService';
 import { TeamService } from './teamService';
-import { computeContentHash, matchesHash } from '../utils/contentHash';
+import { SupabaseClientManager } from './supabaseClient';
 import { getDeviceInfo } from '../utils/deviceId';
-
-/**
- * Mutable sync state for team prompts (simpler than personal SyncState)
- */
-interface TeamSyncState {
-  promptSyncMap: Record<string, PromptSyncInfo>;
-  lastSyncedAt?: Date;
-}
+import { SyncEngine, TeamTransport } from './sync';
+import type { SyncEngineConfig, LocalPromptStore } from './sync';
 
 /**
  * Result of a team sync operation
@@ -52,6 +42,20 @@ export class TeamSyncService {
   ) {}
 
   /**
+   * Validate authentication and set session on Supabase client
+   */
+  private async validateAuthAndSetSession(): Promise<void> {
+    const token = await this.authService.getValidAccessToken();
+    const refreshToken = await this.authService.getRefreshToken();
+
+    if (!token || !refreshToken) {
+      throw new Error('Not authenticated. Please sign in first.');
+    }
+
+    await SupabaseClientManager.setSession(token, refreshToken);
+  }
+
+  /**
    * Sync prompts for all teams the user belongs to
    */
   async syncAllTeams(): Promise<TeamSyncResult[]> {
@@ -59,6 +63,9 @@ export class TeamSyncService {
     if (teams.length === 0) {
       return [];
     }
+
+    // Set auth session once for all teams
+    await this.validateAuthAndSetSession();
 
     const results: TeamSyncResult[] = [];
 
@@ -83,7 +90,7 @@ export class TeamSyncService {
   }
 
   /**
-   * Sync prompts for a single team
+   * Sync prompts for a single team using SyncEngine + TeamTransport
    */
   async syncTeam(team: Team): Promise<TeamSyncResult> {
     const result: TeamSyncResult = {
@@ -96,290 +103,81 @@ export class TeamSyncService {
       errors: [],
     };
 
+    // Ensure auth session is set
+    await this.validateAuthAndSetSession();
+
     const { storage, syncState: syncStateStorage } = await this.teamService.getTeamStorage(team.id);
 
-    // 1. Fetch local prompts and sync state
+    // 1. Get local prompts and ensure sync state is initialized
     const localPrompts = await storage.list();
-    const savedState = await syncStateStorage.getSyncState();
+    let savedState = await syncStateStorage.getSyncState();
 
-    // Build mutable team sync state from persisted state
-    const syncState: TeamSyncState = {
-      promptSyncMap: savedState ? { ...savedState.promptSyncMap } : {},
-    };
-    if (savedState?.lastSyncedAt) {
-      syncState.lastSyncedAt = savedState.lastSyncedAt;
+    if (!savedState) {
+      // Initialize sync state for first team sync
+      const email = (await this.authService.getUserEmail()) || 'unknown';
+      const deviceInfo = await getDeviceInfo(this.context);
+      savedState = await syncStateStorage.initializeSyncState(email, deviceInfo, team.id);
     }
 
-    // 2. Fetch remote team prompts
-    const remotePrompts = await this.fetchTeamPrompts(team.id, true);
+    const promptSyncMap = { ...savedState.promptSyncMap };
+    const lastSyncedAt = savedState.lastSyncedAt;
 
-    // 3. Compute sync plan (last-writer-wins)
-    const plan = this.computeTeamSyncPlan(localPrompts, remotePrompts, syncState, team);
+    // 2. Create transport and engine
+    const transport = new TeamTransport(
+      this.context,
+      this.authService,
+      team.id,
+      team.role
+    );
 
-    // 4. Download remote changes to local
-    for (const remote of plan.toDownload) {
-      try {
-        const localPrompt = this.remoteToLocal(remote, team.id);
-        await storage.save(localPrompt);
-        syncState.promptSyncMap[localPrompt.id] = {
-          cloudId: remote.cloud_id,
-          version: remote.version,
-          lastSyncedContentHash: remote.content_hash,
-          lastSyncedAt: new Date(),
-          isDeleted: false,
-        };
-        result.downloaded++;
-      } catch (err) {
-        result.errors.push(`Download failed for ${remote.cloud_id}: ${err}`);
-      }
-    }
-
-    // 5. Upload local changes (editor+ only)
-    if (canEdit(team.role)) {
-      for (const local of plan.toUpload) {
-        try {
-          const syncInfo = syncState.promptSyncMap[local.id];
-          const uploadResult = await this.uploadTeamPrompt(local, team.id, syncInfo);
-          syncState.promptSyncMap[local.id] = {
-            cloudId: uploadResult.cloudId,
-            version: uploadResult.version,
-            lastSyncedContentHash: computeContentHash(local),
-            lastSyncedAt: new Date(),
-            isDeleted: false,
-          };
-          result.uploaded++;
-        } catch (err) {
-          result.errors.push(`Upload failed for ${local.id}: ${err}`);
-        }
-      }
-    }
-
-    // 6. Delete locally prompts that were deleted remotely
-    for (const deletion of plan.toDeleteLocally) {
-      try {
-        await storage.delete(deletion.localPromptId);
-        if (syncState.promptSyncMap[deletion.localPromptId]) {
-          syncState.promptSyncMap[deletion.localPromptId].isDeleted = true;
-        }
-        result.deleted++;
-      } catch (err) {
-        result.errors.push(`Local delete failed for ${deletion.localPromptId}: ${err}`);
-      }
-    }
-
-    // 7. Save updated sync state - persist via syncStateStorage
-    // We save the promptSyncMap back through the storage layer
-    // For team sync, we only need the promptSyncMap persisted
-    syncState.lastSyncedAt = new Date();
-    if (savedState) {
-      // Update the existing state with our mutable changes
-      const updatedState = {
-        ...savedState,
-        promptSyncMap: Object.freeze(syncState.promptSyncMap),
-        lastSyncedAt: syncState.lastSyncedAt,
-      };
-      await syncStateStorage.saveSyncState(updatedState);
-    }
-
-    return result;
-  }
-
-  /**
-   * Compute team sync plan using last-writer-wins strategy
-   *
-   * Remote always wins on conflict since team prompts are collaborative.
-   */
-  private computeTeamSyncPlan(
-    localPrompts: readonly Prompt[],
-    remotePrompts: readonly RemotePrompt[],
-    syncState: TeamSyncState,
-    team: Team
-  ) {
-    const plan = {
-      toDownload: [] as RemotePrompt[],
-      toUpload: [] as Prompt[],
-      toDeleteLocally: [] as Array<{ localPromptId: string; cloudId: string }>,
+    const engineConfig: SyncEngineConfig = {
+      handleWebCreatedPrompts: false,
+      handleCloudDeletion: false,
+      checkQuota: false,
     };
 
-    const localMap = new Map(localPrompts.map((p) => [p.id, p]));
+    const engine = new SyncEngine(transport, syncStateStorage, engineConfig);
 
-    // Build cloudId -> localId lookup from sync state
-    const cloudIdToLocalId = new Map<string, string>();
-    for (const [promptId, info] of Object.entries(syncState.promptSyncMap)) {
-      if (info.cloudId) {
-        cloudIdToLocalId.set(info.cloudId, promptId);
-      }
-    }
+    // 3. Fetch remote team prompts (including deleted for deletion detection)
+    const remotePrompts = await transport.fetchRemotePrompts(true);
 
-    // Active remote prompts (not deleted)
-    const activeRemote = remotePrompts.filter((r) => !r.deleted_at);
-    const deletedRemote = remotePrompts.filter((r) => r.deleted_at);
+    // 4. Compute sync plan (three-way merge — same as personal)
+    const plan = engine.computeSyncPlan(localPrompts, remotePrompts, lastSyncedAt, promptSyncMap);
 
-    // Process active remote prompts
-    for (const remote of activeRemote) {
-      const localId = cloudIdToLocalId.get(remote.cloud_id);
-      const local = localId ? localMap.get(localId) : undefined;
-
-      if (!local) {
-        // New remote prompt or previously unknown - download
-        plan.toDownload.push(remote);
-        continue;
-      }
-
-      // Both exist - check if remote is newer (last-writer-wins)
-      const syncInfo = syncState.promptSyncMap[local.id];
-      const lastSyncHash = syncInfo?.lastSyncedContentHash;
-      const remoteHash = remote.content_hash;
-
-      const localChanged = lastSyncHash ? !matchesHash(local, lastSyncHash) : false;
-      const remoteChanged = lastSyncHash ? remoteHash !== lastSyncHash : false;
-
-      if (remoteChanged && localChanged) {
-        // Conflict - remote wins (last-writer-wins for team prompts)
-        plan.toDownload.push(remote);
-      } else if (remoteChanged) {
-        // Only remote changed - download
-        plan.toDownload.push(remote);
-      } else if (localChanged && canEdit(team.role)) {
-        // Only local changed and user can edit - upload
-        plan.toUpload.push(local);
-      }
-      // else: no changes - skip
-    }
-
-    // Process remote deletions - delete locally if known
-    for (const remote of deletedRemote) {
-      const localId = cloudIdToLocalId.get(remote.cloud_id);
-      if (localId && localMap.has(localId)) {
-        plan.toDeleteLocally.push({ localPromptId: localId, cloudId: remote.cloud_id });
-      }
-    }
-
-    // Process local-only prompts (no cloudId in sync state) - upload as new
-    if (canEdit(team.role)) {
-      for (const local of localPrompts) {
-        const syncInfo = syncState.promptSyncMap[local.id];
-        if (!syncInfo?.cloudId) {
-          plan.toUpload.push(local);
-        }
-      }
-    }
-
-    return plan;
-  }
-
-  /**
-   * Fetch team prompts from the backend
-   */
-  private async fetchTeamPrompts(teamId: string, includeDeleted = false): Promise<RemotePrompt[]> {
-    const supabase = SupabaseClientManager.get();
-
-    const { data, error } = await supabase.functions.invoke('get-team-prompts', {
-      body: { teamId, includeDeleted },
-    });
-
-    if (error) {
-      const errorContext = (error as { context?: { status?: number } }).context;
-      if (errorContext?.status === 401) {
-        await this.authService.clearInvalidTokens();
-        throw new Error('Your session has expired. Please sign in again.');
-      }
-      if (errorContext?.status === 403) {
-        throw new Error('You are not a member of this team.');
-      }
-      throw new Error(`Failed to fetch team prompts: ${error.message}`);
-    }
-
-    return (data as { prompts: RemotePrompt[] }).prompts || [];
-  }
-
-  /**
-   * Upload a prompt to a team
-   */
-  private async uploadTeamPrompt(
-    prompt: Prompt,
-    teamId: string,
-    syncInfo?: PromptSyncInfo
-  ): Promise<{ cloudId: string; version: number }> {
-    const supabase = SupabaseClientManager.get();
-    const contentHash = computeContentHash(prompt);
-    const deviceInfo = await getDeviceInfo(this.context);
-
-    const body = {
-      teamId,
-      cloudId: syncInfo?.cloudId,
-      expectedVersion: syncInfo?.version,
-      contentHash,
-      local_id: prompt.id,
-      title: prompt.title,
-      content: prompt.content,
-      description: prompt.description || null,
-      category: prompt.category,
-      prompt_order: prompt.order || null,
-      category_order: prompt.categoryOrder || null,
-      variables: prompt.variables,
-      sync_metadata: {
-        lastModifiedDeviceId: deviceInfo.id,
-        lastModifiedDeviceName: deviceInfo.name,
+    // 5. Create local prompt store adapter for FileStorageProvider
+    const localStore: LocalPromptStore = {
+      async savePromptDirectly(prompt: Prompt): Promise<Prompt> {
+        // Add teamId to prompt before saving
+        prompt.teamId = team.id;
+        await storage.save(prompt);
+        return prompt;
+      },
+      async deletePromptById(id: string): Promise<boolean> {
+        return storage.delete(id);
       },
     };
 
-    const { data, error } = await supabase.functions.invoke('sync-team-prompt', {
-      body,
-    });
-
-    if (error) {
-      const errorContext = (error as { context?: { status?: number } }).context;
-      if (errorContext?.status === 401) {
-        await this.authService.clearInvalidTokens();
-        throw new Error('Session expired during team sync.');
-      }
-      if (errorContext?.status === 403) {
-        throw new Error('Insufficient permissions to edit team prompts.');
-      }
-      throw new Error(`Team prompt upload failed: ${error.message}`);
+    // 6. Execute sync plan
+    try {
+      const syncResult = await engine.executeSyncPlan(plan, localStore);
+      result.downloaded = syncResult.stats.downloaded;
+      result.uploaded = syncResult.stats.uploaded;
+      result.deleted = syncResult.stats.deleted;
+      result.conflicts = syncResult.stats.conflicts;
+    } catch (error) {
+      result.errors.push(error instanceof Error ? error.message : String(error));
     }
 
-    const uploadData = data as { cloudId: string; version: number };
-    return { cloudId: uploadData.cloudId, version: uploadData.version };
-  }
-
-  /**
-   * Convert a remote prompt to local Prompt format
-   */
-  private remoteToLocal(remote: RemotePrompt, teamId: string): Prompt {
-    const meta = remote.metadata as { usageCount?: number; lastUsed?: string } | undefined;
-
-    const metadata: Prompt['metadata'] = {
-      created: new Date(remote.created_at),
-      modified: new Date(remote.updated_at),
-      usageCount: meta?.usageCount || 0,
-    };
-    if (meta?.lastUsed) {
-      metadata.lastUsed = new Date(meta.lastUsed);
+    // 7. Update last synced timestamp
+    const currentState = await syncStateStorage.getSyncState();
+    if (currentState) {
+      await syncStateStorage.saveSyncState({
+        ...currentState,
+        lastSyncedAt: new Date(),
+      });
     }
 
-    const prompt: Prompt = {
-      id: remote.local_id || remote.cloud_id,
-      title: remote.title,
-      content: remote.content,
-      category: remote.category || 'General',
-      variables: (remote.variables as TemplateVariable[]) || [],
-      teamId,
-      metadata,
-    };
-
-    if (remote.description) {
-      prompt.description = remote.description;
-    }
-    if (remote.prompt_order != null) {
-      prompt.order = remote.prompt_order;
-    }
-    if (remote.category_order != null) {
-      prompt.categoryOrder = remote.category_order;
-    }
-
-    return prompt;
+    return result;
   }
 
   /**

--- a/src/storage/syncStateStorage.ts
+++ b/src/storage/syncStateStorage.ts
@@ -36,9 +36,10 @@ export class SyncStateStorage {
    * Create a new sync state storage instance
    *
    * @param workspaceRoot - Absolute path to workspace root
+   * @param options - Optional config to override the default storage directory
    */
-  constructor(workspaceRoot: string) {
-    this.syncStateDir = path.join(workspaceRoot, '.vscode', 'prompt-bank');
+  constructor(workspaceRoot: string, options?: { storagePath?: string }) {
+    this.syncStateDir = options?.storagePath ?? path.join(workspaceRoot, '.vscode', 'prompt-bank');
     this.syncStateFile = path.join(this.syncStateDir, 'sync-state.json');
     this.workspaceMetaFile = path.join(this.syncStateDir, 'workspace-meta.json');
   }

--- a/src/views/teamTreeProvider.ts
+++ b/src/views/teamTreeProvider.ts
@@ -1,0 +1,188 @@
+/**
+ * Tree data provider for the Team Prompts sidebar view
+ *
+ * Displays a three-level hierarchy:
+ *   Team (name + role badge) -> Category (with count) -> Prompt
+ *
+ * contextValue encodes the user's role for menu gating in package.json.
+ */
+
+import * as vscode from 'vscode';
+import type { Prompt } from '../models/prompt';
+import type { Team } from '../models/team';
+import type { TeamService } from '../services/teamService';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tree Item Types
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tree item representing a team
+ */
+export class TeamTreeItem extends vscode.TreeItem {
+  constructor(public readonly team: Team) {
+    super(team.name, vscode.TreeItemCollapsibleState.Expanded);
+
+    const roleBadge = team.role.charAt(0).toUpperCase() + team.role.slice(1);
+    this.description = roleBadge;
+    this.tooltip = `${team.name} (${roleBadge})\n${team.memberCount} member${team.memberCount !== 1 ? 's' : ''}${team.description ? `\n${team.description}` : ''}`;
+    this.contextValue = `team_${team.role}`;
+    this.iconPath = new vscode.ThemeIcon('organization');
+  }
+}
+
+/**
+ * Tree item representing a category within a team
+ */
+export class TeamCategoryTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly category: string,
+    public readonly promptCount: number,
+    public readonly team: Team
+  ) {
+    super(`${category} (${promptCount})`, vscode.TreeItemCollapsibleState.Expanded);
+
+    this.tooltip = `Category: ${category} - ${promptCount} prompts`;
+    this.contextValue = `teamCategory_${team.role}`;
+    this.iconPath = new vscode.ThemeIcon('folder');
+  }
+}
+
+/**
+ * Tree item representing a prompt within a team
+ */
+export class TeamPromptTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly prompt: Prompt,
+    public readonly team: Team
+  ) {
+    super(prompt.title, vscode.TreeItemCollapsibleState.None);
+
+    this.tooltip = this.buildTooltip();
+    this.contextValue = `teamPrompt_${team.role}`;
+    this.iconPath = new vscode.ThemeIcon('file-text');
+  }
+
+  private buildTooltip(): string {
+    const lines = [
+      `Title: ${this.prompt.title}`,
+      `Category: ${this.prompt.category}`,
+      `Team: ${this.team.name}`,
+    ];
+
+    if (this.prompt.description) {
+      lines.push(`Description: ${this.prompt.description}`);
+    }
+
+    const preview = this.prompt.content?.substring(0, 100) || 'No content';
+    const ellipsis = (this.prompt.content?.length || 0) > 100 ? '...' : '';
+    lines.push(`Content: ${preview}${ellipsis}`);
+
+    return lines.join('\n');
+  }
+}
+
+/**
+ * Empty state when user has teams but no prompts
+ */
+export class TeamEmptyStateTreeItem extends vscode.TreeItem {
+  constructor(public readonly team: Team) {
+    super('No team prompts yet', vscode.TreeItemCollapsibleState.None);
+    this.contextValue = 'teamEmpty';
+    this.iconPath = new vscode.ThemeIcon('info');
+    this.tooltip = 'This team has no prompts yet';
+  }
+}
+
+export type TeamTreeItemType =
+  | TeamTreeItem
+  | TeamCategoryTreeItem
+  | TeamPromptTreeItem
+  | TeamEmptyStateTreeItem;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tree Data Provider
+// ────────────────────────────────────────────────────────────────────────────
+
+export class TeamTreeProvider implements vscode.TreeDataProvider<TeamTreeItemType> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<
+    TeamTreeItemType | undefined | null | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  /** Cache of team prompts keyed by teamId */
+  private teamPromptsCache = new Map<string, Prompt[]>();
+
+  constructor(private readonly teamService: TeamService) {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  /**
+   * Update cached prompts for a team and refresh the view
+   */
+  setTeamPrompts(teamId: string, prompts: Prompt[]): void {
+    this.teamPromptsCache.set(teamId, prompts);
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: TeamTreeItemType): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: TeamTreeItemType): Promise<TeamTreeItemType[]> {
+    if (!element) {
+      // Root level - return teams
+      return this.getTeamItems();
+    }
+
+    if (element instanceof TeamTreeItem) {
+      // Team level - return categories within this team
+      return this.getCategoryItems(element.team);
+    }
+
+    if (element instanceof TeamCategoryTreeItem) {
+      // Category level - return prompts in this category
+      return this.getPromptItems(element.team, element.category);
+    }
+
+    return [];
+  }
+
+  private getTeamItems(): TeamTreeItemType[] {
+    const teams = this.teamService.getTeams();
+    if (teams.length === 0) {
+      return [];
+    }
+    return teams.map((t) => new TeamTreeItem(t));
+  }
+
+  private getCategoryItems(team: Team): TeamTreeItemType[] {
+    const prompts = this.teamPromptsCache.get(team.id) || [];
+
+    if (prompts.length === 0) {
+      return [new TeamEmptyStateTreeItem(team)];
+    }
+
+    // Group by category
+    const categoryMap = new Map<string, number>();
+    for (const prompt of prompts) {
+      const count = categoryMap.get(prompt.category) || 0;
+      categoryMap.set(prompt.category, count + 1);
+    }
+
+    return Array.from(categoryMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, count]) => new TeamCategoryTreeItem(name, count, team));
+  }
+
+  private getPromptItems(team: Team, category: string): TeamTreeItemType[] {
+    const prompts = this.teamPromptsCache.get(team.id) || [];
+
+    return prompts
+      .filter((p) => p.category === category)
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .map((p) => new TeamPromptTreeItem(p, team));
+  }
+}

--- a/test/e2e/helpers/msw-setup.ts
+++ b/test/e2e/helpers/msw-setup.ts
@@ -20,6 +20,7 @@ export const mswTestServer = {
     server.listen({ onUnhandledRequest: 'warn' });
     oauthTestHelpers.resetTokens();
     oauthTestHelpers.clearAuthCodes();
+    teamSyncTestHelpers.clearAllTeamData();
   },
 
   /**
@@ -29,6 +30,7 @@ export const mswTestServer = {
     server.resetHandlers();
     oauthTestHelpers.resetTokens();
     oauthTestHelpers.clearAuthCodes();
+    teamSyncTestHelpers.clearAllTeamData();
   },
 
   /**

--- a/test/e2e/helpers/msw-setup.ts
+++ b/test/e2e/helpers/msw-setup.ts
@@ -2,9 +2,10 @@ import { setupServer } from 'msw/node';
 import { oauthHandlers, oauthTestHelpers } from './oauth-handlers';
 import { jwksHandler, jwksTestHelpers } from './jwks-handlers';
 import { syncHandlers, syncTestHelpers, TEST_PAST_TIME_OFFSET_MS } from './sync-handlers';
+import { teamSyncHandlers, teamSyncTestHelpers } from './team-sync-handlers';
 
-// Create MSW server with OAuth, JWKS, and Sync handlers
-export const server = setupServer(...oauthHandlers, jwksHandler, ...syncHandlers);
+// Create MSW server with OAuth, JWKS, Sync, and Team Sync handlers
+export const server = setupServer(...oauthHandlers, jwksHandler, ...syncHandlers, ...teamSyncHandlers);
 
 // Enhanced server with helper methods
 export const mswTestServer = {
@@ -63,8 +64,9 @@ export const mswTestServer = {
     oauth: oauthTestHelpers,
     jwks: jwksTestHelpers,
     sync: syncTestHelpers,
+    teamSync: teamSyncTestHelpers,
   },
 };
 
 // Export individual helpers for direct import
-export { oauthTestHelpers, jwksTestHelpers, syncTestHelpers, TEST_PAST_TIME_OFFSET_MS };
+export { oauthTestHelpers, jwksTestHelpers, syncTestHelpers, teamSyncTestHelpers, TEST_PAST_TIME_OFFSET_MS };

--- a/test/e2e/helpers/team-sync-handlers.ts
+++ b/test/e2e/helpers/team-sync-handlers.ts
@@ -1,0 +1,354 @@
+import { http, HttpResponse } from 'msw';
+import type { RemotePrompt } from '../../../src/models/syncState';
+import type { TeamRole } from '../../../src/models/team';
+import { computeContentHash } from '../../../src/utils/contentHash';
+import type { Prompt } from '../../../src/models/prompt';
+
+// In-memory per-team cloud database for team sync testing
+const teamCloudPrompts = new Map<string, Map<string, RemotePrompt>>();
+let currentTeamCloudId = 1;
+
+// Role tracking per team (teamId -> role)
+let mockTeamRoles = new Map<string, TeamRole>();
+
+/**
+ * Time offset for creating timestamps in the past (for testing)
+ */
+export const TEAM_TEST_PAST_TIME_OFFSET_MS = 5000;
+
+function getTeamDb(teamId: string): Map<string, RemotePrompt> {
+  if (!teamCloudPrompts.has(teamId)) {
+    teamCloudPrompts.set(teamId, new Map());
+  }
+  return teamCloudPrompts.get(teamId)!;
+}
+
+function generateTeamCloudId(): string {
+  return `team-cloud-${currentTeamCloudId++}`;
+}
+
+/**
+ * MSW handlers for team edge functions
+ */
+export const teamSyncHandlers = [
+  // Get team prompts
+  http.post('*/functions/v1/get-team-prompts', async ({ request }) => {
+    try {
+      const body = (await request.json()) as {
+        teamId: string;
+        includeDeleted?: boolean;
+      };
+      const { teamId, includeDeleted = false } = body;
+
+      const role = mockTeamRoles.get(teamId);
+      if (!role) {
+        return HttpResponse.json(
+          { error: 'Forbidden', message: 'You are not a member of this team.' },
+          { status: 403 }
+        );
+      }
+
+      const db = getTeamDb(teamId);
+      let prompts = Array.from(db.values());
+
+      if (!includeDeleted) {
+        prompts = prompts.filter((p) => !p.deleted_at);
+      }
+
+      return HttpResponse.json({ prompts });
+    } catch (error) {
+      return HttpResponse.json(
+        { error: 'Failed to fetch team prompts', message: String(error) },
+        { status: 500 }
+      );
+    }
+  }),
+
+  // Sync team prompt (create or update with optimistic locking + role check)
+  http.post('*/functions/v1/sync-team-prompt', async ({ request }) => {
+    try {
+      const body = (await request.json()) as {
+        teamId: string;
+        cloudId?: string;
+        expectedVersion?: number;
+        contentHash: string;
+        local_id: string;
+        title: string;
+        content: string;
+        description?: string | null;
+        category: string;
+        prompt_order?: number | null;
+        category_order?: number | null;
+        variables: unknown[];
+        sync_metadata: {
+          lastModifiedDeviceId: string;
+          lastModifiedDeviceName: string;
+        };
+      };
+
+      const { teamId, cloudId, expectedVersion, contentHash, ...promptData } = body;
+
+      // Role check: editor+ required for writes
+      const role = mockTeamRoles.get(teamId);
+      if (!role || role === 'viewer') {
+        return HttpResponse.json(
+          {
+            success: false,
+            error: 'INSUFFICIENT_ROLE',
+            message: 'Insufficient permissions to edit team prompts.',
+          },
+          { status: 403 }
+        );
+      }
+
+      const db = getTeamDb(teamId);
+
+      // UPDATE existing prompt
+      if (cloudId) {
+        const existingPrompt = db.get(cloudId);
+
+        if (!existingPrompt) {
+          return HttpResponse.json(
+            { error: 'Prompt not found', message: 'Cloud prompt does not exist' },
+            { status: 404 }
+          );
+        }
+
+        // Check if prompt is soft-deleted
+        if (existingPrompt.deleted_at) {
+          return HttpResponse.json(
+            {
+              success: false,
+              error: 'PROMPT_DELETED',
+              message: 'Cannot update a soft-deleted prompt',
+              details: {
+                cloudId: existingPrompt.cloud_id,
+                deletedAt: existingPrompt.deleted_at,
+              },
+            },
+            { status: 409 }
+          );
+        }
+
+        // Optimistic locking check
+        if (expectedVersion !== undefined && existingPrompt.version !== expectedVersion) {
+          return HttpResponse.json(
+            {
+              success: false,
+              error: 'VERSION_CONFLICT',
+              message: 'Prompt version has changed since last sync',
+              details: {
+                expectedVersion,
+                actualVersion: existingPrompt.version,
+                lastModifiedAt: existingPrompt.updated_at,
+              },
+            },
+            { status: 409 }
+          );
+        }
+
+        // Update prompt
+        const updatedPrompt: RemotePrompt = {
+          ...existingPrompt,
+          ...promptData,
+          content_hash: contentHash,
+          version: existingPrompt.version + 1,
+          updated_at: new Date().toISOString(),
+        };
+
+        db.set(cloudId, updatedPrompt);
+
+        return HttpResponse.json({
+          cloudId: cloudId,
+          version: updatedPrompt.version,
+        });
+      }
+
+      // CREATE new prompt
+      const newCloudId = generateTeamCloudId();
+      const newPrompt: RemotePrompt = {
+        id: newCloudId,
+        user_id: 'test-user@promptbank.test',
+        workspace_id: teamId,
+        cloud_id: newCloudId,
+        content_hash: contentHash,
+        version: 1,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        deleted_at: null,
+        ...promptData,
+      };
+
+      db.set(newCloudId, newPrompt);
+
+      return HttpResponse.json({
+        cloudId: newCloudId,
+        version: 1,
+      });
+    } catch (error) {
+      return HttpResponse.json(
+        { error: 'Failed to sync team prompt', message: String(error) },
+        { status: 500 }
+      );
+    }
+  }),
+];
+
+/**
+ * Test helper utilities for team sync tests
+ */
+export const teamSyncTestHelpers = {
+  /**
+   * Set the mock role for a team
+   */
+  setMockRole(teamId: string, role: TeamRole): void {
+    mockTeamRoles.set(teamId, role);
+  },
+
+  /**
+   * Add a prompt to the team cloud database
+   */
+  addTeamCloudPrompt(
+    teamId: string,
+    prompt: Partial<RemotePrompt> & { title: string; content: string; category: string }
+  ): RemotePrompt {
+    const db = getTeamDb(teamId);
+    const cloudId = generateTeamCloudId();
+
+    // Compute content hash from the prompt fields the same way the extension does
+    const mockPrompt: Prompt = {
+      id: prompt.local_id || cloudId,
+      title: prompt.title,
+      content: prompt.content,
+      category: prompt.category,
+      variables: [],
+      metadata: { created: new Date(), modified: new Date(), usageCount: 0 },
+    };
+    const contentHash = prompt.content_hash || computeContentHash(mockPrompt);
+
+    const fullPrompt: RemotePrompt = {
+      id: cloudId,
+      user_id: 'test-user@promptbank.test',
+      workspace_id: teamId,
+      cloud_id: cloudId,
+      local_id: prompt.local_id || null,
+      description: prompt.description || null,
+      prompt_order: prompt.prompt_order ?? null,
+      category_order: prompt.category_order ?? null,
+      variables: prompt.variables || [],
+      metadata: prompt.metadata || {
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        usageCount: 0,
+      },
+      sync_metadata: prompt.sync_metadata || {
+        lastModifiedDeviceId: 'test-device-id',
+        lastModifiedDeviceName: 'Test Device',
+      },
+      content_hash: contentHash,
+      version: prompt.version || 1,
+      created_at: prompt.created_at || new Date().toISOString(),
+      updated_at: prompt.updated_at || new Date().toISOString(),
+      deleted_at: prompt.deleted_at ?? null,
+      title: prompt.title,
+      content: prompt.content,
+      category: prompt.category,
+    };
+
+    db.set(cloudId, fullPrompt);
+    return fullPrompt;
+  },
+
+  /**
+   * Update an existing team cloud prompt
+   */
+  updateTeamCloudPrompt(
+    teamId: string,
+    cloudId: string,
+    updates: Partial<RemotePrompt>
+  ): RemotePrompt | undefined {
+    const db = getTeamDb(teamId);
+    const prompt = db.get(cloudId);
+    if (!prompt) return undefined;
+
+    const updatedPrompt: RemotePrompt = {
+      ...prompt,
+      ...updates,
+      version: prompt.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+
+    // Recompute content hash if title/content/category changed
+    if (updates.title || updates.content || updates.category) {
+      const mockPrompt: Prompt = {
+        id: updatedPrompt.local_id || updatedPrompt.cloud_id,
+        title: updatedPrompt.title,
+        content: updatedPrompt.content,
+        category: updatedPrompt.category,
+        variables: [],
+        metadata: { created: new Date(), modified: new Date(), usageCount: 0 },
+      };
+      updatedPrompt.content_hash = computeContentHash(mockPrompt);
+    }
+
+    db.set(cloudId, updatedPrompt);
+    return updatedPrompt;
+  },
+
+  /**
+   * Soft-delete a team cloud prompt
+   */
+  deleteTeamCloudPrompt(teamId: string, cloudId: string, deletedAt?: Date): boolean {
+    const db = getTeamDb(teamId);
+    const prompt = db.get(cloudId);
+    if (!prompt) return false;
+
+    prompt.deleted_at = (deletedAt ?? new Date()).toISOString();
+    db.set(cloudId, prompt);
+    return true;
+  },
+
+  /**
+   * Soft-delete a team cloud prompt in the past
+   */
+  deleteTeamCloudPromptInPast(teamId: string, cloudId: string): boolean {
+    const pastTime = new Date(Date.now() - TEAM_TEST_PAST_TIME_OFFSET_MS);
+    return this.deleteTeamCloudPrompt(teamId, cloudId, pastTime);
+  },
+
+  /**
+   * Get a team cloud prompt
+   */
+  getTeamCloudPrompt(teamId: string, cloudId: string): RemotePrompt | undefined {
+    return getTeamDb(teamId).get(cloudId);
+  },
+
+  /**
+   * Get all team cloud prompts
+   */
+  getAllTeamCloudPrompts(teamId: string, includeDeleted = false): RemotePrompt[] {
+    const prompts = Array.from(getTeamDb(teamId).values());
+    return includeDeleted ? prompts : prompts.filter((p) => !p.deleted_at);
+  },
+
+  /**
+   * Clear all team data (reset)
+   */
+  clearAllTeamData(): void {
+    teamCloudPrompts.clear();
+    mockTeamRoles.clear();
+    currentTeamCloudId = 1;
+  },
+
+  /**
+   * Simulate version conflict for a team prompt
+   */
+  simulateVersionConflict(teamId: string, cloudId: string): void {
+    const db = getTeamDb(teamId);
+    const prompt = db.get(cloudId);
+    if (prompt) {
+      prompt.version = prompt.version + 1;
+      db.set(cloudId, prompt);
+    }
+  },
+};

--- a/test/team-rbac.test.ts
+++ b/test/team-rbac.test.ts
@@ -1,0 +1,119 @@
+/**
+ * RBAC unit tests for team role hierarchy and permission checks.
+ *
+ * Tests the pure functions in models/team.ts (hasMinRole, canEdit, canDelete)
+ * and verifies TeamTransport.getWritePermission() maps roles correctly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  hasMinRole,
+  canEdit,
+  canDelete,
+  type TeamRole,
+} from '../src/models/team';
+import { TeamTransport } from '../src/services/sync/teamTransport';
+
+// ──────────────────────────────────────────────────────────
+// hasMinRole — role hierarchy checks
+// ──────────────────────────────────────────────────────────
+
+describe('hasMinRole', () => {
+  const roles: TeamRole[] = ['viewer', 'editor', 'admin', 'owner'];
+
+  it('should grant every role its own level', () => {
+    for (const role of roles) {
+      expect(hasMinRole(role, role)).toBe(true);
+    }
+  });
+
+  it('should grant higher roles access to lower thresholds', () => {
+    expect(hasMinRole('owner', 'viewer')).toBe(true);
+    expect(hasMinRole('owner', 'editor')).toBe(true);
+    expect(hasMinRole('owner', 'admin')).toBe(true);
+    expect(hasMinRole('admin', 'viewer')).toBe(true);
+    expect(hasMinRole('admin', 'editor')).toBe(true);
+    expect(hasMinRole('editor', 'viewer')).toBe(true);
+  });
+
+  it('should deny lower roles access to higher thresholds', () => {
+    expect(hasMinRole('viewer', 'editor')).toBe(false);
+    expect(hasMinRole('viewer', 'admin')).toBe(false);
+    expect(hasMinRole('viewer', 'owner')).toBe(false);
+    expect(hasMinRole('editor', 'admin')).toBe(false);
+    expect(hasMinRole('editor', 'owner')).toBe(false);
+    expect(hasMinRole('admin', 'owner')).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// canEdit — editor+ required
+// ──────────────────────────────────────────────────────────
+
+describe('canEdit', () => {
+  it('should allow editor, admin, and owner', () => {
+    expect(canEdit('editor')).toBe(true);
+    expect(canEdit('admin')).toBe(true);
+    expect(canEdit('owner')).toBe(true);
+  });
+
+  it('should deny viewer', () => {
+    expect(canEdit('viewer')).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// canDelete — admin+ required
+// ──────────────────────────────────────────────────────────
+
+describe('canDelete', () => {
+  it('should allow admin and owner', () => {
+    expect(canDelete('admin')).toBe(true);
+    expect(canDelete('owner')).toBe(true);
+  });
+
+  it('should deny viewer and editor', () => {
+    expect(canDelete('viewer')).toBe(false);
+    expect(canDelete('editor')).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// TeamTransport.getWritePermission — role → sync permission mapping
+// ──────────────────────────────────────────────────────────
+
+describe('TeamTransport.getWritePermission', () => {
+  function getPerms(role: TeamRole) {
+    const transport = new TeamTransport(
+      {} as any, // context — not used by getWritePermission
+      {} as any, // authService — not used by getWritePermission
+      'team-1',
+      role
+    );
+    return transport.getWritePermission();
+  }
+
+  it('viewer: cannot upload, cannot delete', () => {
+    const perms = getPerms('viewer');
+    expect(perms.canUpload).toBe(false);
+    expect(perms.canDelete).toBe(false);
+  });
+
+  it('editor: can upload, cannot delete', () => {
+    const perms = getPerms('editor');
+    expect(perms.canUpload).toBe(true);
+    expect(perms.canDelete).toBe(false);
+  });
+
+  it('admin: can upload, can delete', () => {
+    const perms = getPerms('admin');
+    expect(perms.canUpload).toBe(true);
+    expect(perms.canDelete).toBe(true);
+  });
+
+  it('owner: can upload, can delete', () => {
+    const perms = getPerms('owner');
+    expect(perms.canUpload).toBe(true);
+    expect(perms.canDelete).toBe(true);
+  });
+});

--- a/test/team-sync-integration.test.ts
+++ b/test/team-sync-integration.test.ts
@@ -1,0 +1,552 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { TeamSyncService, type TeamSyncResult } from '../src/services/teamSyncService';
+import { AuthService } from '../src/services/authService';
+import { TeamService } from '../src/services/teamService';
+import { SupabaseClientManager } from '../src/services/supabaseClient';
+import { FileStorageProvider } from '../src/storage/fileStorage';
+import { SyncStateStorage } from '../src/storage/syncStateStorage';
+import { createPrompt } from './helpers/prompt-factory';
+import { server, teamSyncTestHelpers } from './e2e/helpers/msw-setup';
+import { computeContentHash } from '../src/utils/contentHash';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type * as vscode from 'vscode';
+import type { Team } from '../src/models/team';
+
+describe('TeamSyncService - Integration (Three-Way Merge)', () => {
+  let teamSyncService: TeamSyncService;
+  let authService: AuthService;
+  let teamService: TeamService;
+  let testStorageDir: string;
+  let context: vscode.ExtensionContext;
+  let teamStorage: FileStorageProvider;
+  let teamSyncStateStorage: SyncStateStorage;
+
+  const TEST_TEAM_ID = 'test-team-001';
+  const TEST_TEAM: Team = {
+    id: TEST_TEAM_ID,
+    name: 'Test Team',
+    description: null,
+    role: 'editor',
+    memberCount: 3,
+    createdAt: new Date().toISOString(),
+  };
+
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'warn' });
+    SupabaseClientManager.initialize();
+  });
+
+  beforeEach(async () => {
+    teamSyncTestHelpers.clearAllTeamData();
+    teamSyncTestHelpers.setMockRole(TEST_TEAM_ID, 'editor');
+
+    testStorageDir = path.join(
+      os.tmpdir(),
+      `prompt-bank-team-sync-test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    );
+
+    const vscode = await import('vscode');
+    context = {
+      globalState: vscode.globalState,
+      workspaceState: vscode.workspaceState,
+      secrets: vscode.secrets,
+      subscriptions: [],
+      extensionUri: vscode.Uri.file(testStorageDir),
+      extensionPath: testStorageDir,
+      extension: {} as any,
+      storageUri: vscode.Uri.file(testStorageDir),
+      globalStorageUri: vscode.Uri.file(path.join(testStorageDir, 'global')),
+      logUri: vscode.Uri.file(path.join(testStorageDir, 'logs')),
+      extensionMode: 3,
+      environmentVariableCollection: {} as any,
+      storagePath: testStorageDir,
+      globalStoragePath: path.join(testStorageDir, 'global'),
+      logPath: path.join(testStorageDir, 'logs'),
+      asAbsolutePath: (relativePath: string) => path.join(testStorageDir, relativePath),
+    } as unknown as vscode.ExtensionContext;
+
+    authService = new AuthService(context, 'test-publisher', 'test-extension');
+    vi.spyOn(authService, 'getValidAccessToken').mockResolvedValue('mock-access-token');
+    vi.spyOn(authService, 'getRefreshToken').mockResolvedValue('mock-refresh-token');
+    vi.spyOn(authService, 'getUserEmail').mockResolvedValue('test-user@promptbank.test');
+
+    // Create team storage in the globalStoragePath
+    const teamStoragePath = path.join(testStorageDir, 'global', 'teams', TEST_TEAM_ID);
+    await fs.mkdir(teamStoragePath, { recursive: true });
+
+    teamStorage = new FileStorageProvider({ storagePath: teamStoragePath });
+    await teamStorage.initialize();
+
+    teamSyncStateStorage = new SyncStateStorage(teamStoragePath, { storagePath: teamStoragePath });
+
+    // Create TeamService with a mock that returns our test team and storage
+    teamService = new TeamService(path.join(testStorageDir, 'global'), authService);
+    // Mock getTeams to return our test team
+    vi.spyOn(teamService, 'getTeams').mockReturnValue([TEST_TEAM]);
+    // Mock getTeamStorage to return our pre-created storage
+    vi.spyOn(teamService, 'getTeamStorage').mockResolvedValue({
+      storage: teamStorage,
+      syncState: teamSyncStateStorage,
+    });
+
+    teamSyncService = new TeamSyncService(context, authService, teamService);
+  });
+
+  afterEach(async () => {
+    await fs.rm(testStorageDir, { recursive: true, force: true }).catch(() => {});
+    server.resetHandlers();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  // Helper to sync a single team and return result
+  async function syncTeam(team: Team = TEST_TEAM): Promise<TeamSyncResult> {
+    return teamSyncService.syncTeam(team);
+  }
+
+  // Helper to list local team prompts
+  async function listLocalPrompts() {
+    return teamStorage.list();
+  }
+
+  // ──────────────────────────────────────────────────────────
+  // First Sync / Downloads
+  // ──────────────────────────────────────────────────────────
+
+  describe('First Sync', () => {
+    it('should download all remote team prompts on first sync', async () => {
+      teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Team Prompt 1',
+        content: 'Content 1',
+        category: 'General',
+        local_id: 'remote-prompt-1',
+      });
+      teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Team Prompt 2',
+        content: 'Content 2',
+        category: 'General',
+        local_id: 'remote-prompt-2',
+      });
+
+      const result = await syncTeam();
+
+      expect(result.downloaded).toBe(2);
+      expect(result.uploaded).toBe(0);
+      expect(result.errors).toHaveLength(0);
+
+      const local = await listLocalPrompts();
+      expect(local).toHaveLength(2);
+      expect(local.map((p) => p.title).sort()).toEqual(['Team Prompt 1', 'Team Prompt 2']);
+    });
+
+    it('should upload new local prompts when user is editor', async () => {
+      const prompt = createPrompt({
+        title: 'New Local Prompt',
+        content: 'Local content',
+        category: 'General',
+      });
+      await teamStorage.save(prompt);
+
+      const result = await syncTeam();
+
+      expect(result.uploaded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const cloud = teamSyncTestHelpers.getAllTeamCloudPrompts(TEST_TEAM_ID);
+      expect(cloud).toHaveLength(1);
+      expect(cloud[0].title).toBe('New Local Prompt');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Role Gating
+  // ──────────────────────────────────────────────────────────
+
+  describe('Role Gating', () => {
+    it('should NOT upload when user is viewer', async () => {
+      const viewerTeam: Team = { ...TEST_TEAM, role: 'viewer' };
+      teamSyncTestHelpers.setMockRole(TEST_TEAM_ID, 'viewer');
+
+      const prompt = createPrompt({
+        title: 'Viewer Prompt',
+        content: 'Viewer content',
+        category: 'General',
+      });
+      await teamStorage.save(prompt);
+
+      const result = await teamSyncService.syncTeam(viewerTeam);
+
+      expect(result.uploaded).toBe(0);
+      expect(result.errors).toHaveLength(0);
+
+      const cloud = teamSyncTestHelpers.getAllTeamCloudPrompts(TEST_TEAM_ID);
+      expect(cloud).toHaveLength(0);
+    });
+
+    it('should still download when user is viewer', async () => {
+      const viewerTeam: Team = { ...TEST_TEAM, role: 'viewer' };
+      teamSyncTestHelpers.setMockRole(TEST_TEAM_ID, 'viewer');
+
+      teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Shared Prompt',
+        content: 'Shared content',
+        category: 'General',
+        local_id: 'shared-1',
+      });
+
+      const result = await teamSyncService.syncTeam(viewerTeam);
+
+      expect(result.downloaded).toBe(1);
+      const local = await listLocalPrompts();
+      expect(local).toHaveLength(1);
+      expect(local[0].title).toBe('Shared Prompt');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Conflict Resolution (THE FIX — no more last-writer-wins)
+  // ──────────────────────────────────────────────────────────
+
+  describe('Conflict Resolution', () => {
+    it('should create two copies when both local and remote changed (not last-writer-wins)', async () => {
+      // Setup: add a remote prompt and sync it to local
+      const remote = teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Shared Prompt',
+        content: 'Original content',
+        category: 'General',
+        local_id: 'conflict-prompt-1',
+      });
+
+      // First sync — downloads the remote prompt
+      await syncTeam();
+
+      let local = await listLocalPrompts();
+      expect(local).toHaveLength(1);
+      const syncedPrompt = local[0];
+
+      // Now modify BOTH local and remote to create a conflict
+      // 1. Modify local
+      const modifiedLocal = {
+        ...syncedPrompt,
+        content: 'Modified locally',
+        metadata: { ...syncedPrompt.metadata, modified: new Date() },
+      };
+      await teamStorage.save(modifiedLocal);
+
+      // 2. Modify remote (different content)
+      teamSyncTestHelpers.updateTeamCloudPrompt(TEST_TEAM_ID, remote.cloud_id, {
+        content: 'Modified remotely',
+        title: 'Shared Prompt',
+        category: 'General',
+        sync_metadata: {
+          lastModifiedDeviceId: 'other-device',
+          lastModifiedDeviceName: 'Other Device',
+        },
+      });
+
+      // Sync again — should detect conflict and create two copies
+      const result = await syncTeam();
+
+      expect(result.conflicts).toBe(1);
+
+      // Verify: two conflict copies exist locally (original deleted + 2 new)
+      local = await listLocalPrompts();
+      expect(local.length).toBe(2);
+
+      // Both copies should have different content
+      const contents = local.map((p) => p.content).sort();
+      expect(contents).toEqual(['Modified locally', 'Modified remotely']);
+
+      // Both titles should include "(from" suffix indicating conflict copies
+      for (const p of local) {
+        expect(p.title).toContain('(from');
+      }
+    });
+
+    it('should not create conflicts when both changed to same content', async () => {
+      const remote = teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Same Edit',
+        content: 'Original content',
+        category: 'General',
+        local_id: 'same-edit-1',
+      });
+
+      await syncTeam();
+
+      let local = await listLocalPrompts();
+      const syncedPrompt = local[0];
+
+      // Both edit to the same content
+      const sameContent = 'Both devices made the same edit';
+      const modifiedLocal = {
+        ...syncedPrompt,
+        content: sameContent,
+        metadata: { ...syncedPrompt.metadata, modified: new Date() },
+      };
+      await teamStorage.save(modifiedLocal);
+
+      teamSyncTestHelpers.updateTeamCloudPrompt(TEST_TEAM_ID, remote.cloud_id, {
+        content: sameContent,
+        title: 'Same Edit',
+        category: 'General',
+      });
+
+      const result = await syncTeam();
+
+      // No conflict because content is identical
+      expect(result.conflicts).toBe(0);
+
+      local = await listLocalPrompts();
+      expect(local).toHaveLength(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Remote Deletion
+  // ──────────────────────────────────────────────────────────
+
+  describe('Remote Deletion', () => {
+    it('should delete locally when remote is soft-deleted', async () => {
+      const remote = teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'To Delete',
+        content: 'Will be deleted',
+        category: 'General',
+        local_id: 'del-1',
+      });
+
+      await syncTeam();
+      let local = await listLocalPrompts();
+      expect(local).toHaveLength(1);
+
+      // Soft-delete remotely
+      teamSyncTestHelpers.deleteTeamCloudPrompt(TEST_TEAM_ID, remote.cloud_id);
+
+      const result = await syncTeam();
+      expect(result.deleted).toBe(1);
+
+      local = await listLocalPrompts();
+      expect(local).toHaveLength(0);
+    });
+
+    it('should preserve local edits when remote deleted but local modified after', async () => {
+      const remote = teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Delete-Modify',
+        content: 'Original',
+        category: 'General',
+        local_id: 'del-mod-1',
+      });
+
+      await syncTeam();
+      let local = await listLocalPrompts();
+      const syncedPrompt = local[0];
+
+      // Remote deletes in the PAST
+      teamSyncTestHelpers.deleteTeamCloudPromptInPast(TEST_TEAM_ID, remote.cloud_id);
+
+      // Local modifies AFTER deletion (by saving with current timestamp)
+      const modifiedLocal = {
+        ...syncedPrompt,
+        content: 'Modified after remote delete',
+        metadata: { ...syncedPrompt.metadata, modified: new Date() },
+      };
+      await teamStorage.save(modifiedLocal);
+
+      const result = await syncTeam();
+
+      // Should re-upload the modified local prompt (preserve work)
+      expect(result.uploaded).toBe(1);
+
+      local = await listLocalPrompts();
+      expect(local).toHaveLength(1);
+      expect(local[0].content).toBe('Modified after remote delete');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Version Conflict Handling
+  // ──────────────────────────────────────────────────────────
+
+  describe('Version Conflict Handling', () => {
+    it('should handle VERSION_CONFLICT by triggering retry', async () => {
+      const remote = teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Version Test',
+        content: 'Original',
+        category: 'General',
+        local_id: 'ver-1',
+      });
+
+      await syncTeam();
+
+      let local = await listLocalPrompts();
+      const syncedPrompt = local[0];
+
+      // Modify locally
+      const modified = {
+        ...syncedPrompt,
+        content: 'Modified locally for version test',
+        metadata: { ...syncedPrompt.metadata, modified: new Date() },
+      };
+      await teamStorage.save(modified);
+
+      // Simulate version conflict (server has higher version)
+      teamSyncTestHelpers.simulateVersionConflict(TEST_TEAM_ID, remote.cloud_id);
+
+      // Sync should fail with conflict retry error
+      const result = await syncTeam();
+
+      // The error should contain the conflict retry code
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('sync_conflict_retry');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Multi-Sync Scenarios
+  // ──────────────────────────────────────────────────────────
+
+  describe('Multi-Sync Scenarios', () => {
+    it('should handle subsequent syncs with only-local changes', async () => {
+      // First sync: download remote
+      teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Existing',
+        content: 'Already in cloud',
+        category: 'General',
+        local_id: 'existing-1',
+      });
+
+      await syncTeam();
+
+      // Second sync: add a local prompt, should upload it
+      const newPrompt = createPrompt({
+        title: 'New Local',
+        content: 'New local content',
+        category: 'General',
+      });
+      await teamStorage.save(newPrompt);
+
+      const result = await syncTeam();
+
+      expect(result.uploaded).toBe(1);
+      expect(result.downloaded).toBe(0);
+      expect(result.conflicts).toBe(0);
+    });
+
+    it('should handle subsequent syncs with only-remote changes', async () => {
+      const remote = teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Remote Only',
+        content: 'Original',
+        category: 'General',
+        local_id: 'remote-only-1',
+      });
+
+      await syncTeam();
+
+      // Remote changes
+      teamSyncTestHelpers.updateTeamCloudPrompt(TEST_TEAM_ID, remote.cloud_id, {
+        content: 'Updated remotely',
+        title: 'Remote Only',
+        category: 'General',
+      });
+
+      const result = await syncTeam();
+
+      expect(result.downloaded).toBe(1);
+      expect(result.uploaded).toBe(0);
+      expect(result.conflicts).toBe(0);
+
+      const local = await listLocalPrompts();
+      const updated = local.find((p) => p.title === 'Remote Only');
+      expect(updated?.content).toBe('Updated remotely');
+    });
+
+    it('should handle no-op sync when nothing changed', async () => {
+      teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Stable',
+        content: 'No changes',
+        category: 'General',
+        local_id: 'stable-1',
+      });
+
+      await syncTeam();
+      const result = await syncTeam();
+
+      expect(result.uploaded).toBe(0);
+      expect(result.downloaded).toBe(0);
+      expect(result.conflicts).toBe(0);
+      expect(result.deleted).toBe(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // syncAllTeams
+  // ──────────────────────────────────────────────────────────
+
+  describe('syncAllTeams', () => {
+    it('should sync all teams and return results', async () => {
+      teamSyncTestHelpers.addTeamCloudPrompt(TEST_TEAM_ID, {
+        title: 'Team 1 Prompt',
+        content: 'Content',
+        category: 'General',
+        local_id: 'all-teams-1',
+      });
+
+      const results = await teamSyncService.syncAllTeams();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].teamId).toBe(TEST_TEAM_ID);
+      expect(results[0].downloaded).toBe(1);
+    });
+
+    it('should return empty array when no teams', async () => {
+      vi.spyOn(teamService, 'getTeams').mockReturnValue([]);
+
+      const results = await teamSyncService.syncAllTeams();
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Admin Role
+  // ──────────────────────────────────────────────────────────
+
+  describe('Admin Role', () => {
+    it('should upload prompts when user is admin', async () => {
+      const adminTeam: Team = { ...TEST_TEAM, role: 'admin' };
+      teamSyncTestHelpers.setMockRole(TEST_TEAM_ID, 'admin');
+
+      const prompt = createPrompt({
+        title: 'Admin Prompt',
+        content: 'Admin content',
+        category: 'General',
+      });
+      await teamStorage.save(prompt);
+
+      const result = await teamSyncService.syncTeam(adminTeam);
+
+      expect(result.uploaded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should upload prompts when user is owner', async () => {
+      const ownerTeam: Team = { ...TEST_TEAM, role: 'owner' };
+      teamSyncTestHelpers.setMockRole(TEST_TEAM_ID, 'owner');
+
+      const prompt = createPrompt({
+        title: 'Owner Prompt',
+        content: 'Owner content',
+        category: 'General',
+      });
+      await teamStorage.save(prompt);
+
+      const result = await teamSyncService.syncTeam(ownerTeam);
+
+      expect(result.uploaded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add team data model with 4-tier role hierarchy (owner > admin > editor > viewer) and role-checking helpers
- Add `TeamService` for extension-level team management using `globalStoragePath` (not workspace-scoped)
- Add `TeamSyncService` with three-way merge sync for team prompts (same algorithm as personal sync)
- Add `TeamTreeProvider` with three-level tree hierarchy (Team > Category > Prompt) and role-based context menus
- Register 7 team commands: sync, refresh, new, edit, delete, copy to clipboard, fork to personal library
- Wire team services as global singletons in `ServicesContainer` with proper lifecycle management
- Extract shared `SyncEngine` with `SyncTransport` interface — both personal and team sync use identical three-way merge with conflict copies

## Design decisions

- **Global scope (not workspace-scoped)**: Team prompts are visible in every VS Code workspace. Teams are organizational, not project-specific.
- **Unified sync engine**: Both personal and team sync use the same three-way merge algorithm via `SyncEngine`. Conflicts create two copies instead of silently overwriting — honoring "Prompt Bank never silently discards your work."
- **Transport abstraction**: `PersonalTransport` and `TeamTransport` implement `SyncTransport` for mode-specific edge function calls and role gating, while `SyncEngine` owns the merge logic.
- **Role-based gating**: Context menus use `viewItem` regex patterns (`teamPrompt_(editor|admin|owner)`) so VS Code enforces role visibility natively. `TeamTransport.getWritePermission()` gates sync uploads/deletes by role.

## Test plan

- [x] Verify `npx tsc --noEmit` passes (0 errors)
- [x] Verify `npm run build` succeeds
- [x] Verify `npm test` passes (204/204, 24 files — including 16 team sync + 11 RBAC tests)
- [ ] Manual: activate extension with team membership — team tree view appears
- [ ] Manual: sync team prompts — prompts populate tree
- [ ] Manual: viewer role — no edit/delete in context menu; sync downloads only
- [ ] Manual: editor role — can create/edit but not delete; sync uploads new/modified
- [ ] Manual: admin role — full CRUD access including cloud deletion
- [ ] Manual: both-sides-changed conflict — two copies created (not last-writer-wins)

Generated with [Claude Code](https://claude.com/claude-code)